### PR TITLE
 Fixes being able to drop defib paddles

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -233,7 +233,7 @@
 	force = 0
 	throwforce = 6
 	w_class = 4
-	// flags = NODROP
+	flags = NODROP
 
 	var/revivecost = 1000
 	var/cooldown = 0
@@ -287,6 +287,8 @@
 	var/mob/living/carbon/human/H = M
 
 	if(busy)
+		return
+	if(istype(M, /obj) || istype(M, /turf))
 		return
 	if(!defib.powered)
 		user.visible_message("<span class='notice'>[defib] beeps: Unit is unpowered.</span>")


### PR DESCRIPTION
Fixes being able to put defibrillator paddles in disposal bins, on tables, on racks, etc. by making them NODROP and fixes any strange side effects of this change by making them not interact with turfs or objects (other than putting the paddles back in the defib pack).
