### PR TITLE
Throwing knives added as a traitor item

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -433,6 +433,13 @@ var/list/uplink_items = list()
 	cost = 4
 	excludefrom = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/stealthy_weapons/throwing
+	name = "Throwing Knife"
+	desc = "Hasbro's latest in their line of pure evil , a knife that deals devestating damage when thrown , still good for shanking the clown to death though."
+	item = /obj/item/weapon/throwingknife
+	cost = 6 //same as the combat knife
+	surplus = 50
+
 /datum/uplink_item/stealthy_weapons/soap
 	name = "Syndicate Soap"
 	desc = "A sinister-looking surfactant used to clean blood stains to hide murders and prevent DNA analysis. You can also drop it underfoot to slip people."

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -19,6 +19,21 @@
 	user << "<font color='red'> You have <b>BANNED</b> [M]</font>"
 	playsound(loc, 'sound/effects/adminhelp.ogg', 15) //keep it at 15% volume so people don't jump out of their skin too much
 
+/obj/item/weapon/throwingknife
+	name = "Throwing knife"
+	desc = "Take it to partys , have a drink with it , stab the clown to death!"
+	icon = 'icons/obj/kitchen.dmi'
+	icon_state = "knife"
+	item_state = "knife"
+	force = 3.0 
+	stun_on_hit = 3 //new variable , ill explain in the pull request.
+	throw_range = 10
+	throwforce = 30.0 //lots of force = lots of fun
+	slot_flags = SLOT_BELT | SLOT_POCKET
+	bleedcap = 0
+	bleedchance = 50
+	embedchance = 70
+	w_class = 1
 
 /obj/item/weapon/nullrod
 	name = "null rod"

--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -2,6 +2,7 @@
 	name = "weapon"
 	icon = 'icons/obj/weapons.dmi'
 	var/no_hitsound = 0 //Make this 1 if you want no hitsounds
+	var/stun_on_hit = 0
 
 /obj/item/weapon/New()
 	..()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -45,7 +45,9 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 		if(istype(I,/obj/item/weapon)) //If the item is a weapon...
 			var/obj/item/weapon/W = I
 			dtype = W.damtype
-
+			if(W.stun_on_hit > 0)//not sure if already implemented , just set a variable and stun from here
+				Stun(W.stun_on_hit)
+				Weaken(W.stun_on_hit)
 			if (W.throwforce > 0) //If the weapon's throwforce is greater than zero...
 				if (W.throwhitsound) //...and throwhitsound is defined...
 					playsound(loc, W.throwhitsound, volume, 1, -1) //...play the weapon's throwhitsound.


### PR DESCRIPTION
New stealthy weapon , very high bleed chance on either throw or stab , very high embed chance (throw only) and a decent amount of damage when thrown compared to a tiny amount of damage when stabbing. 6 Telecrystals.

Other implementations: Implemented new Weapon variable , meaning weapons can set stun_on_hit = > 0 in order to stun when thrown at a player.
