### PR TITLE
Disabled injecting chemicals directly into spray bottles.

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -148,7 +148,9 @@
 				return
 			if(istype(target, /obj/item/weapon/implantcase/chem))
 				return
-
+			if(istype(target, /obj/item/weapon/reagent_containers/spray))
+				user << "<span class='notice'>You cannot inject directly into the spray bottle using syringes.</span>"
+				return
 			if(!target.is_open_container() && !target.is_injectable() && !ismob(target))
 				user << "<span class='notice'>You cannot directly fill [target].</span>"
 				return


### PR DESCRIPTION
Could be used later with a checker to more specifically filter out banned chems. Quick fix for now

issue #215
