### PR TITLE
Goodcurity & admin alert levels

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -31,7 +31,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 	var/const/STATE_ALERT_LEVEL = 8
 	var/const/STATE_CONFIRM_LEVEL = 9
 	var/const/STATE_TOGGLE_EMERGENCY = 10
-	
+
 	l_color = "#FFFFFF"
 
 	var/status_display_freq = "1435"
@@ -93,7 +93,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 					var/old_level = security_level
 					if(!tmp_alertlevel) tmp_alertlevel = SEC_LEVEL_GREEN
 					if(tmp_alertlevel < SEC_LEVEL_GREEN) tmp_alertlevel = SEC_LEVEL_GREEN
-					if(tmp_alertlevel > SEC_LEVEL_BLUE) tmp_alertlevel = SEC_LEVEL_BLUE //Cannot engage delta with this
+					if(tmp_alertlevel > SEC_LEVEL_BLUE && !M.client.goodcurity) tmp_alertlevel = SEC_LEVEL_BLUE //Cannot engage delta with this unless goodcurity
 					set_security_level(tmp_alertlevel)
 					if(security_level != old_level)
 						//Only notify the admins if an actual change happened
@@ -420,10 +420,13 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 		if(STATE_ALERT_LEVEL)
 			dat += "Current alert level: [get_security_level()]<BR>"
 			if(security_level == SEC_LEVEL_DELTA)
-				dat += "<font color='red'><b>The self-destruct mechanism is active. Find a way to deactivate the mechanism to lower the alert level or evacuate.</b></font>"
+				dat += "<A HREF='?src=\ref[src];operation=securitylevel;newalertlevel=[SEC_LEVEL_RED]'>Red</A>"
 			else
 				dat += "<A HREF='?src=\ref[src];operation=securitylevel;newalertlevel=[SEC_LEVEL_BLUE]'>Blue</A><BR>"
-				dat += "<A HREF='?src=\ref[src];operation=securitylevel;newalertlevel=[SEC_LEVEL_GREEN]'>Green</A>"
+				dat += "<A HREF='?src=\ref[src];operation=securitylevel;newalertlevel=[SEC_LEVEL_GREEN]'>Green</A><BR>"
+				if(user.client.goodcurity)
+					dat += "<A HREF='?src=\ref[src];operation=securitylevel;newalertlevel=[SEC_LEVEL_DELTA]'>Delta</A>"
+
 		if(STATE_CONFIRM_LEVEL)
 			dat += "Current alert level: [get_security_level()]<BR>"
 			dat += "Confirm the change to: [num2seclevel(tmp_alertlevel)]<BR>"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -93,7 +93,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 					var/old_level = security_level
 					if(!tmp_alertlevel) tmp_alertlevel = SEC_LEVEL_GREEN
 					if(tmp_alertlevel < SEC_LEVEL_GREEN) tmp_alertlevel = SEC_LEVEL_GREEN
-					if(tmp_alertlevel > SEC_LEVEL_BLUE && !M.client.goodcurity) tmp_alertlevel = SEC_LEVEL_BLUE //Cannot engage delta with this unless goodcurity
+					if(tmp_alertlevel > SEC_LEVEL_BLUE) tmp_alertlevel = SEC_LEVEL_BLUE //Cannot engage delta with this unless goodcurity
 					set_security_level(tmp_alertlevel)
 					if(security_level != old_level)
 						//Only notify the admins if an actual change happened
@@ -161,7 +161,18 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 				src.state = STATE_VIEWMESSAGE
 		if("status")
 			src.state = STATE_STATUSDISPLAY
-
+		if("requestdelta")
+			if(src.authenticated==2)
+				if(CM.cooldown)
+					usr << "Arrays recycling.  Please stand by."
+					return
+				var/input = stripped_input(usr, "Please explain why you're requesting Code Delta.  Transmission does not guarantee a response.", "To abort, send an empty message.", "")
+				if(!input || !(usr in view(1,src)))
+					return
+				request_delta(usr, input)
+				usr << "Code delta request sent."
+				log_say("[key_name(usr)] has requested Code Delta.")
+				CM.cooldown = 55
 		if("securitylevel")
 			src.tmp_alertlevel = text2num( href_list["newalertlevel"] )
 			if(!tmp_alertlevel) tmp_alertlevel = 0
@@ -425,7 +436,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 				dat += "<A HREF='?src=\ref[src];operation=securitylevel;newalertlevel=[SEC_LEVEL_BLUE]'>Blue</A><BR>"
 				dat += "<A HREF='?src=\ref[src];operation=securitylevel;newalertlevel=[SEC_LEVEL_GREEN]'>Green</A><BR>"
 				if(user.client.goodcurity)
-					dat += "<A HREF='?src=\ref[src];operation=securitylevel;newalertlevel=[SEC_LEVEL_DELTA]'>Delta</A>"
+					dat += "<A HREF='?src=\ref[src];operation=requestdelta'>Delta</A>"
 
 		if(STATE_CONFIRM_LEVEL)
 			dat += "Current alert level: [get_security_level()]<BR>"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -483,14 +483,14 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretscoder=infinite_sec'>Remove cap on security officers</A><BR>
 			<BR>
 			"}
-	if(check_rights(R_FUN,0) && check_rights(R_DEBUG,0))
-		dat += {"
-			<A href='?src=\ref[src];secretscoder=alert_green'>Switch station to Code Green</A><BR>
-			<A href='?src=\ref[src];secretscoder=alert_blue'>Switch station to Code Blue</A><BR>
-			<A href='?src=\ref[src];secretscoder=alert_red'>Switch station to Code Red</A><BR>
-			<A href='?src=\ref[src];secretscoder=alert_delta'>Switch station to Code Delta</A><BR>
-			<BR>
-			"}
+		if(check_rights(R_FUN,0))
+			dat += {"
+				<A href='?src=\ref[src];secretscoder=alert_green'>Switch station to Code Green</A><BR>
+				<A href='?src=\ref[src];secretscoder=alert_blue'>Switch station to Code Blue</A><BR>
+				<A href='?src=\ref[src];secretscoder=alert_red'>Switch station to Code Red</A><BR>
+				<A href='?src=\ref[src];secretscoder=alert_delta'>Switch station to Code Delta</A><BR>
+				<BR>
+				"}
 
 	usr << browse(dat, "window=secrets")
 	return

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -483,6 +483,14 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretscoder=infinite_sec'>Remove cap on security officers</A><BR>
 			<BR>
 			"}
+	if(check_rights(R_FUN,0) && check_rights(R_DEBUG,0))
+		dat += {"
+			<A href='?src=\ref[src];secretscoder=alert_green'>Switch station to Code Green</A><BR>
+			<A href='?src=\ref[src];secretscoder=alert_blue'>Switch station to Code Blue</A><BR>
+			<A href='?src=\ref[src];secretscoder=alert_red'>Switch station to Code Red</A><BR>
+			<A href='?src=\ref[src];secretscoder=alert_delta'>Switch station to Code Delta</A><BR>
+			<BR>
+			"}
 
 	usr << browse(dat, "window=secrets")
 	return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2277,6 +2277,26 @@ var/global/list/achievements = list("Goodcurity")
 		if(!check_rights(R_DEBUG))	return
 
 		switch(href_list["secretscoder"])
+			if("alert_green")
+				set_security_level("green")
+				message_admins("[key_name_admin(usr)] set the station to Code Green")
+				log_admin("[key_name_admin(usr)] set the station to Code Green")
+				return
+			if("alert_blue")
+				set_security_level("blue")
+				message_admins("[key_name_admin(usr)] set the station to Code Blue")
+				log_admin("[key_name_admin(usr)] set the station to Code Blue")
+				return
+			if("alert_red")
+				set_security_level("red")
+				message_admins("[key_name_admin(usr)] set the station to Code Red")
+				log_admin("[key_name_admin(usr)] set the station to Code Red")
+				return
+			if("alert_delta")
+				set_security_level("delta")
+				message_admins("[key_name_admin(usr)] set the station to Code Delta")
+				log_admin("[key_name_admin(usr)] set the station to Code Delta")
+				return
 			if("maint_access_brig")
 				for(var/obj/machinery/door/airlock/maintenance/M in world)
 					M.check_access()

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -36,3 +36,7 @@
 	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN)
 	msg = "<span class='adminnotice'><b><font color=crimson>SYNDICATE:</font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[Sender]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;SyndicateReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
 	admins << msg
+
+/proc/request_delta(var/mob/Sender, var/reason,)
+	var/msg = "<span class='adminnotice'> <b><font color=orange>CODE DELTA REQUESTED BY:</font> [key_name(Sender, 1)]. REASON: [reason] (<a HREF='?_src_=holder;secretscoder=alert_delta'>Authorize</a></span>)"
+	admins << msg


### PR DESCRIPTION
Per Nokingtons request

Allows admins to set any alert level at will via the secrets panel.

Allows those with the goodcurity achievement to set code delta via the communications console. Inline with the goodcurity "fix" (as it was previously existent but lost, apparently), code delta can be changed to code red via the communications console now, allowing goodcurity to revert martial law when it's no longer needed..
