### PR TITLE
Fixes objects not being un-embedded by admin revives

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -429,6 +429,9 @@
 			if(limbs.len)
 				for(var/obj/item/organ/limb/L in limbs)
 					L.bloodloss = 0 //Set bleeding to 0
+					for(var/obj/item/I in L.embedded)
+						L.embedded -= I
+						I.loc = src.loc
 		if(C.reagents)
 			for(var/datum/reagent/R in C.reagents.reagent_list)
 				C.reagents.clear_reagents()


### PR DESCRIPTION
As it says on the tin. Now admin rejuvenates won't leave you with ten bullets, three throwing knives, a raccoon and something resembling a bite from a rabid admin.
