### PR TITLE
Change name of practice laser projectile to practice laser

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -9,7 +9,7 @@
 	eyeblur = 2
 
 /obj/item/projectile/practice
-	name = "laser"
+	name = "practice laser"
 	icon_state = "laser"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	damage = 0


### PR DESCRIPTION
Simple change, meant for fixing the logging of the practice laser projectile type.
