### PR TITLE
Cleans up mentorhelps, mentor PMs and msay.

### DIFF
--- a/code/modules/mentor/verbs/mentorhelp.dm
+++ b/code/modules/mentor/verbs/mentorhelp.dm
@@ -13,7 +13,7 @@
 	if(!msg)	return
 	if(!mob)	return						//this doesn't happen
 
-	var/mentor_msg = "<span class='mentornotice'><font color='purple'>New Mentor PM From <b>[key_name_mentor(src, 1, 0, 1)]</b>: [msg]</font></span>"
+	var/mentor_msg = "<span class='mentornotice'><b><font color='purple'>MENTORHELP:</b> <b>[key_name_mentor(src, 1, 0, 1)]</b>: [msg]</font></span>"
 	log_mentor("MENTORHELP: " + msg)
 
 	for(var/client/X in mentors)
@@ -24,7 +24,7 @@
 		A << 'sound/Items/Bikehorn2.ogg'
 		A << mentor_msg
 
-	src << "<span class='mentornotice'><font color='purple'>Mentor PM Sent: [msg]</font></span>"
+	src << "<span class='mentornotice'><font color='purple'>PM to-<b>Mentors</b>: [msg]</font></span>"
 	return
 
 /proc/key_name_mentor(var/whom, var/include_link = null, var/include_name = 0, var/include_follow = 0)
@@ -75,6 +75,6 @@
 		. += "*no key*"
 
 	if(include_follow)
-		. += " <a href='?mentor_follow=\ref[M]'>(F)</a>"
+		. += " (<a href='?mentor_follow=\ref[M]'>F</a>)"
 
 	return .

--- a/code/modules/mentor/verbs/mentorpm.dm
+++ b/code/modules/mentor/verbs/mentorpm.dm
@@ -45,8 +45,8 @@
 
 	msg = emoji_parse(msg)
 	C << 'sound/Items/Bikehorn2.ogg'
-	C << "<font color='purple'>Mentor PM From <b>[key_name_mentor(src, C, 1, check_mentor(C) && !check_mentor(src))]</b>: [msg]</font>"
-	src << "<font color='green'>Mentor PM To <b>[key_name_mentor(C, src, 1, check_mentor(src) && !check_mentor(C))]</b>: [msg]</font>"
+	C << "<font color='purple'>Mentor PM from-<b>[key_name_mentor(src, C, 1, check_mentor(C) && !check_mentor(src))]</b>: [msg]</font>"
+	src << "<font color='green'>Mentor PM to-<b>[key_name_mentor(C, src, 1, check_mentor(src) && !check_mentor(C))]</b>: [msg]</font>"
 
 	//we don't use message_Mentors here because the sender/receiver might get it too
 	for(var/client/X in mentors)

--- a/code/modules/mentor/verbs/mentorsay.dm
+++ b/code/modules/mentor/verbs/mentorsay.dm
@@ -1,6 +1,7 @@
 /client/proc/cmd_mentor_say(msg as text)
 	set category = "Mentor"
-	set name = "Msay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
+	set name = "Msay" //Gave this shit a shorter name so you only have to time out "msay" rather than "mentor say" to use it --NeoFite
+	set hidden = 1
 	if(!check_mentor())	return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
@@ -9,11 +10,11 @@
 	log_mentor("[key_name(src)] : [msg]")
 
 	if(check_rights(R_ADMIN,0))
-		msg = "<span class='mentoradmin'><span class='prefix'>MENTOR:</span> <EM>[src.ckey]</EM> : <span class='message'>[msg]</span></span>"
+		msg = "<span class='mentoradmin'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></span>"
 		mentors << msg
 		admins << msg
 
 	else
-		msg = "<span class='mentor'><span class='prefix'>MENTOR:</span> <EM>[src.ckey]</EM> : <span class='message'>[msg]</span></span>"
+		msg = "<span class='mentor'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></span>"
 		mentors << msg
 		admins << msg


### PR DESCRIPTION
Mentorhelps show up as MENTORHELP: as opposed to "New Mentor PM from". To the user, it shows up as "PM to mentors" as well.
Msay now uses a formatted version of the mentor/admins key
MentorPMs to and forth have similar formatting to adminPMs, sans the admin part
Msay verb now hidden from tabs, similar to asay

Mostly for consistency and so it looks a bit better.
