### PR TITLE
Gives security their sechailers back

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -76,6 +76,7 @@ Warden
 	default_backpack = /obj/item/weapon/storage/backpack/security
 	default_satchel = /obj/item/weapon/storage/backpack/satchel_sec
 	default_dufflebag = /obj/item/weapon/storage/backpack/dufflebag_security
+	default_storagebox = /obj/item/weapon/storage/box/security
 
 	access = list(access_security, access_sec_doors, access_brig, access_armory, access_court, access_maint_tunnels, access_morgue, access_weapons)
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_armory, access_court, access_weapons) //See /datum/job/warden/get_access()

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -26,6 +26,7 @@ Head of Security
 	default_backpack = /obj/item/weapon/storage/backpack/security
 	default_satchel = /obj/item/weapon/storage/backpack/satchel_sec
 	default_dufflebag = /obj/item/weapon/storage/backpack/dufflebag_security
+	default_storagebox = /obj/item/weapon/storage/box/security
 
 /datum/job/hos/get_access()
 	return get_all_accesses()
@@ -178,6 +179,7 @@ Security Officer
 	default_backpack = /obj/item/weapon/storage/backpack/security
 	default_satchel = /obj/item/weapon/storage/backpack/satchel_sec
 	default_dufflebag = /obj/item/weapon/storage/backpack/dufflebag_security
+	default_storagebox = /obj/item/weapon/storage/box/security
 
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_morgue, access_weapons)
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_court, access_weapons) //But see /datum/job/warden/get_access()

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -76,6 +76,16 @@
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 	return
 
+/obj/item/weapon/storage/box/security
+
+/obj/item/weapon/storage/box/security/New()
+	..()
+	contents = list()
+	new /obj/item/clothing/mask/gas/sechailer(src)
+	new /obj/item/weapon/tank/emergency_oxygen(src)
+	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
+	return
+
 /obj/item/weapon/storage/box/gloves
 	name = "box of latex gloves"
 	desc = "Contains sterile latex gloves."

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -65,6 +65,7 @@
 	ignore_maskadjust = 0
 	flags = MASKCOVERSMOUTH | BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	flags_inv = HIDEFACE
+	w_class = 2.0
 	visor_flags = MASKCOVERSMOUTH | BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACE
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -62,6 +62,7 @@ should be listed in the changelog upon commit tho. Thanks. -->
 	<ul class='changes bgimages16'>
 		<li class='tweak'>Removes the chance to fail when emagging a Cyborg.</a></li>
 		<li class='rscadd'>Puts 3 fannypacks into the ClothesMate finally.</li>
+		<li class='tweak'>Security now spawns with sechailers in their internals box.</a></li>
 	</ul>
 </div>
 


### PR DESCRIPTION
This means that security no longer starts with normal gasmasks in their boxes, but sechailers instead. Someone on TG removed this for some reason.
