### PR TITLE
Mob and admin/mentor fixes

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -610,6 +610,12 @@ var/global/list/achievements = list("Goodcurity")
 		else
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=wizard;jobban4=\ref[M]'>[replacetext("Wizard", " ", "&nbsp")]</a></td>"
 
+		//Shadowlings
+		if(jobban_isbanned(M, "shadowling") || isbanned_dept)
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=shadowling;jobban4=\ref[M]'><font color=red>[replacetext("Shadowling", " ", "&nbsp")]</font></a></td>"
+		else
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=shadowling;jobban4=\ref[M]'>[replacetext("Shadowling", " ", "&nbsp")]</a></td>"
+
 /*		//Malfunctioning AI	//Removed Malf-bans because they're a pain to impliment
 		if(jobban_isbanned(M, "malf AI") || isbanned_dept)
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=malf AI;jobban4=\ref[M]'><font color=red>[replacetext("Malf AI", " ", "&nbsp")]</font></a></td>"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -85,7 +85,7 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	if(!mob)	return						//this doesn't happen
 
 	var/ref_mob = "\ref[mob]"
-	msg = "<span class='adminnotice'><b><font color=red>HELP: </font>[key_name(src, 1)] (<A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A>) (<A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=[ref_mob]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) [ai_found ? " (<A HREF='?_src_=holder;adminchecklaws=[ref_mob]'>CL</A>)" : ""]:</b> [msg]</span>"
+	msg = "<span class='adminnotice'><b><font color=red>ADMINHELP: </font>[key_name(src, 1)] (<A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A>) (<A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=[ref_mob]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) [ai_found ? " (<A HREF='?_src_=holder;adminchecklaws=[ref_mob]'>CL</A>)" : ""]:</b> [msg]</span>"
 
 	//send this msg to all admins
 	var/admin_number_total = 0		//Total number of admins

--- a/code/modules/mentor/verbs/mentorpm.dm
+++ b/code/modules/mentor/verbs/mentorpm.dm
@@ -51,7 +51,7 @@
 	//we don't use message_Mentors here because the sender/receiver might get it too
 	for(var/client/X in mentors)
 		if(X.key!=key && X.key!=C.key)	//check client/X is an Mentor and isn't the sender or recipient
-			X << "<B><font color='green'>Mentor PM: [key_name_mentor(src, X, 0, !check_mentor(src))]-&gt;[key_name_mentor(C, X, 0, !check_mentor(C))]:</B> \blue [msg]</font>" //inform X
+			X << "<B><font color='green'>Mentor PM: [key_name_mentor(src, X, 0, 0)]-&gt;[key_name_mentor(C, X, 0, 0)]:</B> \blue [msg]</font>" //inform X
 	for(var/client/A in admins)
 		if(A.key!=key && A.key!=C.key)	//check client/A is an Mentor and isn't the sender or recipient
-			A << "<B><font color='green'>Mentor PM: [key_name_mentor(src, A, 0, !check_mentor(src))]-&gt;[key_name_mentor(C, A, 0, !check_mentor(C))]:</B> \blue [msg]</font>" //inform A
+			A << "<B><font color='green'>Mentor PM: [key_name_mentor(src, A, 0, 0)]-&gt;[key_name_mentor(C, A, 0, 0)]:</B> \blue [msg]</font>" //inform A

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -456,7 +456,7 @@
 
 		if(config.health_threshold_crit >= health) //Newcrit!
 			nearcrit = 1
-			if(stat == CONSCIOUS)
+			if(stat != DEAD)
 				adjustOxyLoss(1)
 				Weaken(3)
 				if(prob(15))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -412,6 +412,7 @@
 	sdisabilities = 0
 	disabilities = 0
 	blinded = 0
+	sleeping = 0
 	eye_blind = 0
 	eye_blurry = 0
 	ear_deaf = 0
@@ -420,6 +421,9 @@
 	ExtinguishMob()
 	fire_stacks = 0
 	suiciding = 0
+	eye_stat = 0
+	eye_blind = 0
+	eye_blurry = 0
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src
 		C.handcuffed = initial(C.handcuffed)


### PR DESCRIPTION
Fixes admins not being able to ban people from shadowling (https://github.com/HippieStationCode/HippieStation13/issues/533)
Adminhelps now say "ADMINHELP" instead of "HELP" for consistency against mentorhelps.
Mentor PMs now no longer show the follow button all the time, only for mentorhelps.
Fixes mobs not dying properly if sleeping or knocked out whilst in critical. (https://github.com/HippieStationCode/HippieStation13/issues/151)
Fixes rejuvenating a mob not fixing eye damage(s) and not waking them up.
