### PR TITLE
Changes how backpacks work.

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -21,6 +21,7 @@
 	slot_flags = SLOT_BACK	//ERROOOOO
 	max_w_class = 3
 	max_combined_w_class = 21
+	storage_slots = 21
 
 /obj/item/weapon/storage/backpack/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	playsound(src.loc, "rustle", 50, 1, -5)
@@ -81,7 +82,6 @@
 	icon_state = "giftbag0"
 	item_state = "giftbag"
 	w_class = 4.0
-	storage_slots = 20 //Can store a lot.
 	max_w_class = 3
 	max_combined_w_class = 60
 
@@ -199,7 +199,6 @@
 	desc = "A very slim satchel that can easily fit into tight spaces."
 	icon_state = "satchel-flat"
 	w_class = 3 //Can fit in backpacks itself.
-	storage_slots = 5
 	max_combined_w_class = 15
 	level = 1
 	cant_hold = list(/obj/item/weapon/storage/backpack/satchel_flat) //muh recursive backpacks

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -283,7 +283,7 @@
 	item_state = "bandolier"
 	storage_slots = 6
 	can_hold = list(
-		"/obj/item/ammo_casing/shotgun"
+		/obj/item/ammo_casing/shotgun
 		)
 
 /obj/item/weapon/storage/belt/bandolier/full/New()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -146,6 +146,7 @@
 
 	if(display_contents_with_number)
 		for(var/datum/numbered_display/ND in display_contents)
+			ND.sample_object.mouse_opacity = 2
 			ND.sample_object.screen_loc = "[cx]:16,[cy]:16"
 			ND.sample_object.maptext = "<font color='white'>[(ND.number > 1)? "[ND.number]" : ""]</font>"
 			ND.sample_object.layer = 20
@@ -155,6 +156,7 @@
 				cy--
 	else
 		for(var/obj/O in contents)
+			O.mouse_opacity = 2 //This is here so storage items that spawn with contents correctly have the "click around item to equip"
 			O.screen_loc = "[cx]:16,[cy]:16"
 			O.maptext = ""
 			O.layer = 20
@@ -213,7 +215,7 @@
 		return 0 //Means the item is already in the storage item
 	if(contents.len >= storage_slots)
 		if(!stop_messages)
-			usr << "<span class='notice'>[src] is full, make some space.</span>"
+			usr << "<span class='notice'>[W] won't fit in [src], make some space.</span>"
 		return 0 //Storage item is full
 
 	if(can_hold.len)
@@ -288,6 +290,7 @@
 		orient2hud(usr)
 		for(var/mob/M in can_see_contents())
 			show_to(M)
+	W.mouse_opacity = 2 //So you can click on the area around the item to equip it, instead of having to pixel hunt
 	update_icon()
 	return 1
 
@@ -317,6 +320,7 @@
 		W.maptext = ""
 	W.on_exit_storage(src)
 	update_icon()
+	W.mouse_opacity = initial(W.mouse_opacity)
 	return 1
 
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -12,6 +12,7 @@
 	if(!O)
 		return 0
 
+	O.mouse_opacity = 2
 	if(istype(O,/obj/item/borg/sight))
 		var/obj/item/borg/sight/S = O
 		sight_mode &= ~S.sight_mode
@@ -53,6 +54,7 @@
 		src << "<span class='notice'>Already activated</span>"
 		return
 	if(!module_state_1)
+		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_1 = O
 		O.layer = 20
 		O.screen_loc = inv1.screen_loc
@@ -60,6 +62,7 @@
 		if(istype(module_state_1,/obj/item/borg/sight))
 			sight_mode |= module_state_1:sight_mode
 	else if(!module_state_2)
+		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_2 = O
 		O.layer = 20
 		O.screen_loc = inv2.screen_loc
@@ -67,6 +70,7 @@
 		if(istype(module_state_2,/obj/item/borg/sight))
 			sight_mode |= module_state_2:sight_mode
 	else if(!module_state_3)
+		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_3 = O
 		O.layer = 20
 		O.screen_loc = inv3.screen_loc

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -61,6 +61,14 @@ should be listed in the changelog upon commit tho. Thanks. -->
 	<h2 class='date'>13 September 2015</h2>
 	<h3 class='author'>Chronitonity updated:</h3>
 	<ul class='changes bgimages16'>
+		<li class='rscadd'>Changes how storage works. Backpacks now hold things based on size, and are able to hold up to 21 items.</li>
+		<li class='tweak'>This means that you can store a lot of small items, like pens, but not as many huge items.</li>
+		<li class='rscadd'>Clicking anywhere around an item in storage item now grabs an item removing annoying precision clicking.</li>
+	</ul>
+
+	<h2 class='date'>13 September 2015</h2>
+	<h3 class='author'>Chronitonity updated:</h3>
+	<ul class='changes bgimages16'>
 		<li class='rscadd'>Adds the bandolier to the game, a belt that can hold 8 shotgun shells. Only the bartender starts with one.</li>
 		<li class='rscadd'>Allows belts to be made using the biogenerator.</li>
 	</ul>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -58,7 +58,7 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 <div class='commit sansserif'>
 
-	<h2 class='date'>13 September 2015</h2>
+	<h2 class='date'>14 September 2015</h2>
 	<h3 class='author'>Chronitonity updated:</h3>
 	<ul class='changes bgimages16'>
 		<li class='rscadd'>Changes how storage works. Backpacks now hold things based on size, and are able to hold up to 21 items.</li>


### PR DESCRIPTION
Backpacks now hold up to 21 items, however this is based on size meaning you can put 21 pens in, but not 21 boxes or crowbars.

You could do this before by just filling your backpack with boxes, but honestly fuck that, if you want to carry around 21 pens, go for it.

ALSO this allows you to click the opaque squares around items in storage to grab them, meaning no more extreme precision clicking for everyone.
