### PR TITLE
Mentor and security record console fixes

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -514,7 +514,7 @@ What a mess.*/
 				switch(href_list["field"])
 					if("name")
 						if (istype(active1, /datum/data/record) || istype(active2, /datum/data/record))
-							var/t1 = input("Please input name:", "Secure. records", active1.fields["name"], null)  as text
+							var/t1 = copytext(sanitize(input("Please input name:", "Secure. records", active1.fields["name"], null)  as text),1,MAX_MESSAGE_LEN)
 							if ((!( t1 ) || !length(trim(t1)) || !( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon)))) || active1 != a1)
 								return
 							if(istype(active1, /datum/data/record))

--- a/code/modules/mentor/verbs/mentorhelp.dm
+++ b/code/modules/mentor/verbs/mentorhelp.dm
@@ -14,7 +14,7 @@
 	if(!mob)	return						//this doesn't happen
 
 	var/mentor_msg = "<span class='mentornotice'><b><font color='purple'>MENTORHELP:</b> <b>[key_name_mentor(src, 1, 0, 1)]</b>: [msg]</font></span>"
-	log_mentor("MENTORHELP: " + msg)
+	log_mentor("MENTORHELP: [key_name_mentor(src, 0, 0, 0)]: [msg]")
 
 	for(var/client/X in mentors)
 		X << 'sound/Items/Bikehorn2.ogg'


### PR DESCRIPTION
Fixes mentorhelps not being logged properly.
Sanitizes the security record consoles's "name" input.
