### PR TITLE
Fixes mulebot causing fucked up pixel_y if the mob loaded is resting

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -460,7 +460,7 @@ obj/machinery/bot/mulebot/bot_reset()
 
 
 	load.loc = loc
-	load.pixel_y -= 9
+	load.pixel_y = 0
 	load.layer = initial(load.layer)
 	if(dirn)
 		var/turf/T = loc

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -61,7 +61,8 @@ should be listed in the changelog upon commit tho. Thanks. -->
 	<ul class='changes bgimages16'>
 		<li class='tweak'>Fixes healing not removing bullets</li>
 		<li class='tweak'>Fixes ammo boxes for ak922 not working on ak922 magazines</li>
-		<li class='tweak'>NEW:Fixes c90gl grenadelauncher not shooting!</li>
+		<li class='tweak'>Fixes c90gl grenadelauncher not shooting!</li>
+		<li class='tweak'>Fixes loading a resting human on a mulebot and then unloading causing pixel_y issues</li>
 	</ul>
 
 <div class='commit sansserif'>


### PR DESCRIPTION
as the title says
