### PR TITLE
Admin logging updates

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -297,12 +297,16 @@ Release Pressure: <A href='?src=\ref[src];pressure_adj=-1000'>-</A> <A href='?sr
 			if (valve_open)
 				if (holding)
 					release_log += "Valve was <b>closed</b> by [usr] ([usr.ckey]), stopping the transfer into the [holding]<br>"
+					add_logs(usr, src, "closed", object=null, addition="(INTENT: [uppertext(usr.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 				else
 					release_log += "Valve was <b>closed</b> by [usr] ([usr.ckey]), stopping the transfer into the <font color='red'><b>air</b></font><br>"
+					add_logs(usr, src, "closed", object=null, addition="(INTENT: [uppertext(usr.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 			else
 				if (holding)
 					release_log += "Valve was <b>opened</b> by [usr] ([usr.ckey]), starting the transfer into the [holding]<br>"
+					add_logs(usr, src, "opened", object=null, addition=", transferring into [holding] (INTENT: [uppertext(usr.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 				else
+					add_logs(usr, src, "opened", object=null, addition=", trasnferring into the air (INTENT: [uppertext(usr.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 					release_log += "Valve was <b>opened</b> by [usr] ([usr.ckey]), starting the transfer into the <font color='red'><b>air</b></font><br>"
 			valve_open = !valve_open
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -111,7 +111,7 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	src << "<span class='adminnotice'>PM to-<b>Admins</b>: [original_msg]</span>"
 
 	var/admin_number_present = admin_number_total - admin_number_decrease	//Number of admins who are neither afk nor invalid
-	log_admin("HELP: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins who have +BAN.")
+	log_admin("ADMINHELP: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins who have +BAN.")
 	if(admin_number_present <= 0)
 		if(!admin_number_afk && !admin_number_ignored)
 			send2irc(ckey, "[original_msg] - No admins online")

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -7,7 +7,7 @@
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	if(!msg)	return
 
-	log_admin("[key_name(src)] : [msg]")
+	log_admin("ASAY: [key_name(src)] : [msg]")
 
 	msg = emoji_parse(msg)
 
@@ -17,6 +17,6 @@
 	else
 		msg = "<span class='adminobserver'><span class='prefix'>ADMIN:</span> <EM>[key_name(usr, 1)]:</EM> <span class='message'>[msg]</span></span>"
 		admins << msg
-	
+
 	feedback_add_details("admin_verb","M") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -15,7 +15,7 @@
 		return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
-	log_admin("[key_name(src)] : [msg]")
+	log_admin("DSAY: [key_name(src)] : [msg]")
 
 	if (!msg)
 		return

--- a/code/modules/mentor/verbs/mentorpm.dm
+++ b/code/modules/mentor/verbs/mentorpm.dm
@@ -41,7 +41,7 @@
 	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
 	if(!msg)	return
 
-	log_mentor("PM: [key_name(src)]->[key_name(C)]: [msg]")
+	log_mentor("Mentor PM: [key_name(src)]->[key_name(C)]: [msg]")
 
 	msg = emoji_parse(msg)
 	C << 'sound/Items/Bikehorn2.ogg'

--- a/code/modules/mentor/verbs/mentorsay.dm
+++ b/code/modules/mentor/verbs/mentorsay.dm
@@ -7,7 +7,7 @@
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	if(!msg)	return
 
-	log_mentor("[key_name(src)] : [msg]")
+	log_mentor("MSAY: [key_name(src)] : [msg]")
 
 	if(check_rights(R_ADMIN,0))
 		msg = "<span class='mentoradmin'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></span>"

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -557,6 +557,7 @@
 						if(lose_butt)
 							visible_message("\red <b>[src]</b>'s ass hits <b>[M]</b> in the face!", "\red Your ass smacks <b>[M]</b> in the face!")
 							M.apply_damage(15,"brute","head")
+							add_logs(src, M, "farted on", object=null, addition=" (DAMAGE DEALT: 15)")
 						else
 							visible_message("\red <b>[src]</b> farts in <b>[M]</b>'s face!")
 
@@ -568,6 +569,7 @@
 					if(M != src)
 						visible_message("\red <b>[src]</b>'s ass blasts <b>[M]</b> in the face!", "\red You ass blast <b>[M]</b>!")
 						M.apply_damage(75,"brute","head")
+						add_logs(src, M, "superfarted on", object=null, addition=" (DAMAGE DEALT: 75)")
 
 				visible_message("\red <b>[src]</b> blows their ass off!", "\red Holy shit, your butt flies off in an arc!")
 


### PR DESCRIPTION
Adminhelp logs changed to "ADMINHELP" from "HELP" for consistency.
Asay and dsay now shows the channel before the log contents, to better differentiate where what was said by an admin
Mentor PMs and msay show "Mentor PM" and "msay" before the log contents, to better differentiate where what was said
Damaging farts are now logged properly in the attacker and victims attack logs
Opening canisters are now logged properly in the attack logs of whoever opens them.
