### PR TITLE
Mentor PM fix

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -29,7 +29,8 @@
 		return
 
 	if(href_list["mentor_msg"])
-		cmd_mentor_pm(href_list["mentor_msg"],null)
+		var/mob/M = locate(href_list["mentor_msg"])
+		cmd_mentor_pm(M,null)
 		return
 
 	if(href_list["mentor_follow"])

--- a/code/modules/mentor/verbs/mentorhelp.dm
+++ b/code/modules/mentor/verbs/mentorhelp.dm
@@ -60,7 +60,7 @@
 
 	if(key)
 		if(include_link)
-			. += "<a href='?mentor_msg=[ckey]'>"
+			. += "<a href='?mentor_msg=\ref[M]'>"
 
 		if(C && C.holder && C.holder.fakekey)
 			. += "Administrator"

--- a/code/modules/mentor/verbs/mentorpm.dm
+++ b/code/modules/mentor/verbs/mentorpm.dm
@@ -19,7 +19,10 @@
 //Fetching a message if needed. src is the sender and C is the target client
 /client/proc/cmd_mentor_pm(whom, msg)
 	var/client/C
-	if(istext(whom))
+	if(istype(whom,/mob))
+		var/mob/M = whom
+		C = M.client
+	else if(istext(whom))
 		C = directory[whom]
 	else if(istype(whom,/client))
 		C = whom


### PR DESCRIPTION
Fixes mentors being able to see ckeys by hovering over the mob name. Whoopsy.
