### PR TITLE
Fixes issue #649 Stun batons with a plasma battery will now no longer infinitely stun after a explosion

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -39,10 +39,11 @@
 			status = 0
 			update_icon()
 			playsound(loc, "sparks", 75, 1, -1)
-		if(bcell.use(chrgdeductamt))
-			return 1
 		else
-			return 0
+			if(bcell.use(chrgdeductamt))
+				status = 0
+				update_icon()
+				playsound(loc, "sparks", 75, 1, -1)
 
 /obj/item/weapon/melee/baton/update_icon()
 	if(status)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -26,11 +26,11 @@
 /obj/item/weapon/stock_parts/cell/proc/use(var/amount)
 	if(rigged && amount > 0)
 		explode()
+		charge = 0
+		return 1
+	else
+		charge = (charge - amount)
 		return 0
-
-	if(charge < amount)	return 0
-	charge = (charge - amount)
-	return 1
 
 // recharge the cell
 /obj/item/weapon/stock_parts/cell/proc/give(var/amount)


### PR DESCRIPTION
This is my first time creating a pull request for your repository so let me know if I did things the way you like it. Also I didn't make any changes to change log as I'm not sure if a certain person does that.

TO TEST
1: Get a syringe with 5u plasma and inject a power cell
2: Insert it into stun baton
3: Throw it at a human until it explodes. 
4: Now the stun baton is out of charge and must replace the battery to make it stun again.
