### PR TITLE
Traitor Folder Exchange chance increased, Makes Agent ID's rewritable.

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -111,7 +111,7 @@
 		var/is_hijacker = prob(10)
 		var/martyr_chance = prob(20)
 		var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
-		if(!exchange_blue && traitors.len >= 4) 	//Set up an exchange if there are enough traitors
+		if(!exchange_blue && traitors.len >= 8) 	//Set up an exchange if there are enough traitors
 			if(!exchange_red)
 				exchange_red = traitor
 			else

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -141,26 +141,26 @@ update_label("John Doe", "Clowny")
 			if(user.mind.special_role)
 				usr << "<span class='notice'>The card's microscanners activate as you pass it over the ID, copying its access.</span>"
 
+/obj/item/weapon/card/id/syndicate/attack_self(mob/user)
+	if(istype(user, /mob/living) && user.mind)
+		if(user.mind.special_role)
+			if(alert(user, "Action", "Agent ID", "Show", "Forge") == "Forge")
+				var t = copytext(sanitize(input(user, "What name would you like to put on this card?", "Agent card name", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name))as text | null),1,26)
+				if(!t || t == "Unknown" || t == "floor" || t == "wall" || t == "r-wall") //Same as mob/new_player/prefrences.dm
+					if (t)
+						alert("Invalid name.")
+					return
+				registered_name = t
 
-/obj/item/weapon/card/id/syndicate/attack_self(mob/user as mob)
-	if(!src.registered_name)
-		//Stop giving the players unsanitized unputs! You are giving ways for players to intentionally crash clients! -Nodrak
-		var t = copytext(sanitize(input(user, "What name would you like to put on this card?", "Agent card name", ishuman(user) ? user.real_name : user.name)),1,26)
-		if(!t || t == "Unknown" || t == "floor" || t == "wall" || t == "r-wall") //Same as mob/new_player/prefrences.dm
-			alert("Invalid name.")
-			return
-		src.registered_name = t
-
-		var u = copytext(sanitize(input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Assistant")),1,MAX_MESSAGE_LEN)
-		if(!u)
-			alert("Invalid assignment.")
-			src.registered_name = ""
-			return
-		src.assignment = u
-		update_label()
-		user << "<span class='notice'>You successfully forge the ID card.</span>"
-	else
-		..()
+				var u = copytext(sanitize(input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Assistant")as text | null),1,MAX_MESSAGE_LEN)
+				if(!u)
+					registered_name = ""
+					return
+				assignment = u
+				update_label()
+				user << "<span class='notice'>You successfully forge the ID card.</span>"
+				return
+	..()
 
 /obj/item/weapon/card/id/syndicate_command
 	name = "syndicate ID card"
@@ -191,7 +191,7 @@ update_label("John Doe", "Clowny")
 /obj/item/weapon/card/id/admin/New()
 	access = get_absolutely_all_accesses()
 	..()
-	
+
 /obj/item/weapon/card/id/centcom
 	name = "\improper Centcom ID"
 	desc = "An ID straight from Cent. Com."

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -56,7 +56,16 @@ should be listed in the changelog upon commit tho. Thanks. -->
 <!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGJS #ADDTOCHANGELOGMARKER# -->
 
 <div class='commit sansserif'>
-	<h2 class='date'>26 September 2015</h2>
+	<h2 class='date'>27 September 2015</h2>
+	<h3 class='author'>Chronitonity updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>Adds the ability for Agent ID cards to be rewritable. Change your name as many times as you need.</li>
+		<li class='tweak'>Chances for traitors to exchange documents have been increased.</li>
+	</ul>
+</div>
+
+<div class='commit sansserif'>
+	<h2 class='date'>27 September 2015</h2>
 	<h3 class='author'>Chronitonity updated:</h3>
 	<ul class='changes bgimages16'>
 		<li class='tweak'>Removes some traitor guns from different Z levels, populates it with goofy shit and possible guardian injectors.</li>


### PR DESCRIPTION
Makes it more likely that traitors will get an "exchange folders with another traitor" objective. This promoted some good fun and IC interaction. Or backstabbing. Either way its good.

This also makes Agent Id's rewritable if you click on them. No one uses these because they're pretty shit, hopefully this alleviates some of that thought.
