### PR TITLE
Makes Combat Mechs scale from parts

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -4,6 +4,15 @@
 	damage_absorption = list("brute"=0.7,"fire"=1,"bullet"=0.7,"laser"=0.85,"energy"=1,"bomb"=0.8)
 	var/am = "d3c2fbcadca903a41161ccc9df9cf948"
 
+/obj/mecha/combat/CheckParts(atom/holder)
+	var/obj/item/weapon/stock_parts/capacitor/C = locate() in holder
+	var/obj/item/weapon/stock_parts/scanning_module/SM = locate() in holder
+	step_energy_drain = 20 - (5 * SM.rating) //10 is normal, so on lowest part its worse, on second its ok and on higher its real good up to 0 on best
+	var/DR = damage_absorption["energy"]
+	damage_absorption["energy"] = DR - (C.rating / 10) //Each level of capacitor protects the mech against emp by 10%
+	qdel(C)
+	qdel(SM)
+
 /obj/mecha/combat/moved_inside(var/mob/living/carbon/human/H as mob)
 	if(..())
 		if(H.client)

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -336,7 +336,7 @@
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="Advanced capacitor is installed."),
 					 //8
-					 list("key"=/obj/item/weapon/stock_parts/capacitor/adv,
+					 list("key"=/obj/item/weapon/stock_parts/capacitor,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="Advanced scanner module is secured."),
 					 //9
@@ -344,7 +344,7 @@
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="Advanced scanner module is installed."),
 					 //10
-					 list("key"=/obj/item/weapon/stock_parts/scanning_module/adv,
+					 list("key"=/obj/item/weapon/stock_parts/scanning_module,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="Weapon control module is secured."),
 					 //11
@@ -473,39 +473,45 @@
 				holder.icon_state = "gygax8"
 		if(10)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs advanced scanner module to the [holder].", "You install advanced scanner module to the [holder].")
-				qdel(used_atom)
+				user.visible_message("[user] installs scanner module to the [holder].", "<span class='notice'>You install scanner module to the [holder].</span>")
+				var/obj/item/I = used_atom
+				user.unEquip(I)
+				I.loc = holder
 				holder.icon_state = "gygax11"
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "You unfasten the weapon control module.")
 				holder.icon_state = "gygax9"
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the advanced scanner module.", "You secure the advanced scanner module.")
+				user.visible_message("[user] secures the advanced scanner module.", "<span class='notice'>You secure the scanner module.</span>")
 				holder.icon_state = "gygax12"
 			else
-				user.visible_message("[user] removes the advanced scanner module from the [holder].", "You remove the advanced scanner module from the [holder].")
-				new /obj/item/weapon/stock_parts/scanning_module/adv(get_turf(holder))
+				user.visible_message("[user] removes the advanced scanner module from the [holder].", "<span class='notice'>You remove the scanner module from the [holder].</span>")
+				var/obj/item/I = locate(/obj/item/weapon/stock_parts/scanning_module) in holder
+				I.loc = get_turf(holder)
 				holder.icon_state = "gygax10"
 		if(8)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs advanced capacitor to the [holder].", "You install advanced capacitor to the [holder].")
-				qdel(used_atom)
+				user.visible_message("[user] installs capacitor to the [holder].", "<span class='notice'>You install capacitor to the [holder].</span>")
+				var/obj/item/I = used_atom
+				user.unEquip(I)
+				I.loc = holder
 				holder.icon_state = "gygax13"
 			else
-				user.visible_message("[user] unfastens the advanced scanner module.", "You unfasten the advanced scanner module.")
+				user.visible_message("[user] unfastens the  scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 				holder.icon_state = "gygax11"
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the advanced capacitor.", "You secure the advanced capacitor.")
+				user.visible_message("[user] secures the  capacitor.", "<span class='notice'>You secure the capacitor.</span>")
 				holder.icon_state = "gygax14"
 			else
-				user.visible_message("[user] removes the advanced capacitor from the [holder].", "You remove the advanced capacitor from the [holder].")
-				new /obj/item/weapon/stock_parts/capacitor/adv(get_turf(holder))
+				user.visible_message("[user] removes the  capacitor from the [holder].", "<span class='notice'>You remove the capacitor from the [holder].</span>")
+				var/obj/item/I = locate(/obj/item/weapon/stock_parts/capacitor) in holder
+				I.loc = get_turf(holder)
 				holder.icon_state = "gygax12"
 		if(6)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the internal armor layer to the [holder].", "You install the internal armor layer to the [holder].")
+				user.visible_message("[user] unfastens the capacitor.", "<span class='notice'>You unfasten the capacitor.</span>")
 				holder.icon_state = "gygax15"
 			else
 				user.visible_message("[user] unfastens the advanced capacitor.", "You unfasten the advanced capacitor.")
@@ -551,7 +557,9 @@
 	return 1
 
 /datum/construction/reversible/mecha/gygax/spawn_result()
-	..()
+	var/obj/mecha/combat/gygax/M = new result(get_turf(holder))
+	M.CheckParts(holder)
+	qdel(holder)
 	feedback_inc("mecha_gygax_created",1)
 	return
 
@@ -914,7 +922,7 @@
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="Super capacitor is installed."),
 					 //8
-					 list("key"=/obj/item/weapon/stock_parts/capacitor/super,
+					 list("key"=/obj/item/weapon/stock_parts/capacitor,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="Phasic scanner module is secured."),
 					 //9
@@ -922,7 +930,7 @@
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="Phasic scanner module is installed."),
 					 //10
-					 list("key"=/obj/item/weapon/stock_parts/scanning_module/phasic,
+					 list("key"=/obj/item/weapon/stock_parts/scanning_module,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="Weapon control module is secured."),
 					 //11
@@ -1052,35 +1060,41 @@
 				holder.icon_state = "durand8"
 		if(10)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs phasic scanner module to the [holder].", "You install phasic scanner module to the [holder].")
-				qdel(used_atom)
+				user.visible_message("[user] installs scanner module to the [holder].", "<span class='notice'>You install phasic scanner module to the [holder].</span>")
+				var/obj/item/I = used_atom
+				user.unEquip(I)
+				I.loc = holder
 				holder.icon_state = "durand11"
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "You unfasten the weapon control module.")
 				holder.icon_state = "durand9"
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the phasic scanner module.", "You secure the phasic scanner module.")
+				user.visible_message("[user] secures the scanner module.", "<span class='notice'>You secure the scanner module.</span>")
 				holder.icon_state = "durand12"
 			else
-				user.visible_message("[user] removes the phasic scanner module from the [holder].", "You remove the phasic scanner module from the [holder].")
-				new /obj/item/weapon/stock_parts/scanning_module/phasic(get_turf(holder))
+				user.visible_message("[user] removes the scanner module from the [holder].", "<span class='notice'>You remove the scanner module from the [holder].</span>")
+				var/obj/item/I = locate(/obj/item/weapon/stock_parts/scanning_module) in holder
+				I.loc = get_turf(holder)
 				holder.icon_state = "durand10"
 		if(8)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs super capacitor to the [holder].", "You install super capacitor to the [holder].")
-				qdel(used_atom)
+				user.visible_message("[user] installs capacitor to the [holder].", "<span class='notice'>You install capacitor to the [holder].</span>")
+				var/obj/item/I = used_atom
+				user.unEquip(I)
+				I.loc = holder
 				holder.icon_state = "durand13"
 			else
-				user.visible_message("[user] unfastens the phasic scanner module.", "You unfasten the phasic scanner module.")
+				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 				holder.icon_state = "durand11"
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the super capacitor.", "You secure the super capacitor.")
+				user.visible_message("[user] secures the capacitor.", "<span class='notice'>You secure the capacitor.</span>")
 				holder.icon_state = "durand14"
 			else
-				user.visible_message("[user] removes the super capacitor from the [holder].", "You remove the super capacitor from the [holder].")
-				new /obj/item/weapon/stock_parts/capacitor/super(get_turf(holder))
+				user.visible_message("[user] removes the super capacitor from the [holder].", "<span class='notice'>You remove the capacitor from the [holder].</span>")
+				var/obj/item/I = locate(/obj/item/weapon/stock_parts/capacitor) in holder
+				I.loc = get_turf(holder)
 				holder.icon_state = "durand12"
 		if(6)
 			if(diff==FORWARD)
@@ -1130,7 +1144,9 @@
 	return 1
 
 /datum/construction/reversible/mecha/durand/spawn_result()
-	..()
+	var/obj/mecha/combat/gygax/M = new result(get_turf(holder))
+	M.CheckParts(holder)
+	qdel(holder)
 	feedback_inc("mecha_durand_created",1)
 	return
 
@@ -1208,7 +1224,7 @@
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="Super capacitor is installed."),
 					 //11
-					 list("key"=/obj/item/weapon/stock_parts/capacitor/super,
+					 list("key"=/obj/item/weapon/stock_parts/capacitor,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="Phasic scanner module is secured."),
 					 //12
@@ -1346,7 +1362,10 @@
 				holder.icon_state = "phazon8"
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs phasic scanner module to the [holder].", "You install phasic scanner module to the [holder].")
+				user.visible_message("[user] installs phasic scanner module to the [holder].", "<span class='notice'>You install scanner module to the [holder].</span>")
+				var/obj/item/I = used_atom
+				user.unEquip(I)
+				I.loc = holder
 				qdel(used_atom)
 				holder.icon_state = "phazon11"
 			else
@@ -1354,27 +1373,31 @@
 				holder.icon_state = "phazon9"
 		if(12)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the phasic scanner module.", "You secure the phasic scanner module.")
+				user.visible_message("[user] secures the phasic scanner module.", "<span class='notice'>You secure the scanner module.</span>")
 				holder.icon_state = "phazon12"
 			else
-				user.visible_message("[user] removes the phasic scanner module from the [holder].", "You remove the phasic scanner module from the [holder].")
-				new /obj/item/weapon/stock_parts/scanning_module/phasic(get_turf(holder))
+				user.visible_message("[user] removes the phasic scanner module from the [holder].", "<span class='notice'>You remove the scanner module from the [holder].</span>")
+				var/obj/item/I = locate(/obj/item/weapon/stock_parts/scanning_module) in holder
+				I.loc = get_turf(holder)
 				holder.icon_state = "phazon10"
 		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs super capacitor to the [holder].", "You install super capacitor to the [holder].")
-				qdel(used_atom)
+				user.visible_message("[user] installs super capacitor to the [holder].", "<span class='notice'>You install capacitor to the [holder].</span>")
+				var/obj/item/I = used_atom
+				user.unEquip(I)
+				I.loc = holder
 				holder.icon_state = "phazon13"
 			else
-				user.visible_message("[user] unfastens the phasic scanner module.", "You unfasten the phasic scanner module.")
+				user.visible_message("[user] unfastens the phasic scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 				holder.icon_state = "phazon11"
 		if(10)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the super capacitor.", "You secure the super capacitor.")
+				user.visible_message("[user] secures the super capacitor.", "<span class='notice'>You secure the capacitor.</span>")
 				holder.icon_state = "phazon14"
 			else
-				user.visible_message("[user] removes the super capacitor from the [holder].", "You remove the super capacitor from the [holder].")
-				new /obj/item/weapon/stock_parts/capacitor/super(get_turf(holder))
+				user.visible_message("[user] removes the super capacitor from the [holder].", "<span class='notice'>You remove the capacitor from the [holder].</span>")
+				var/obj/item/I = locate(/obj/item/weapon/stock_parts/capacitor) in holder
+				I.loc = get_turf(holder)
 				holder.icon_state = "phazon12"
 		if(9)
 			if(diff==FORWARD)
@@ -1382,7 +1405,7 @@
 				qdel(used_atom)
 				holder.icon_state = "phazon15"
 			else
-				user.visible_message("[user] unsecures the super capacitor from the [holder].", "You unsecure the super capacitor from the [holder].")
+				user.visible_message("[user] unsecures the super capacitor from the [holder].", "<span class='notice'>You unsecure the capacitor from the [holder].</span>")
 				holder.icon_state = "phazon13"
 		if(8)
 			if(diff==FORWARD)
@@ -1447,7 +1470,9 @@
 	return 1
 
 /datum/construction/reversible/mecha/phazon/spawn_result()
-	..()
+	var/obj/mecha/combat/gygax/M = new result(get_turf(holder))
+	M.CheckParts(holder)
+	qdel(holder)
 	feedback_inc("mecha_phazon_created",1)
 	return
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -59,6 +59,8 @@ should be listed in the changelog upon commit tho. Thanks. -->
 	<h2 class='date'>27 September 2015</h2>
 	<h3 class='author'>Chronitonity updated:</h3>
 	<ul class='changes bgimages16'>
+		<li class='tweak'>Phazons, Durands, and Gygaxs no longer need Advanced Scanning Modules or Capacitors, you can use the normal variants of them to build your mech.</li>
+		<li class='rscadd'>Combat Mechs powers scale based on the Capacitor and Scanning Module you used. Giving higher EMP resistance and less power drain from movement respectively.</li>
 		<li class='rscadd'>Adds the ability for Agent ID cards to be rewritable. Change your name as many times as you need.</li>
 		<li class='tweak'>Chances for traitors to exchange documents have been increased.</li>
 	</ul>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -67,7 +67,7 @@ should be listed in the changelog upon commit tho. Thanks. -->
 </div>
 
 <div class='commit sansserif'>
-	<h2 class='date'>27 September 2015</h2>
+	<h2 class='date'>26 September 2015</h2>
 	<h3 class='author'>Chronitonity updated:</h3>
 	<ul class='changes bgimages16'>
 		<li class='tweak'>Removes some traitor guns from different Z levels, populates it with goofy shit and possible guardian injectors.</li>


### PR DESCRIPTION
Removes the requirement for Advanced Capacitors and Advanced Scanning Modules for Phazons, Gygaxs, and Durands, instead you can use normal Capacitors and Scanning Modules.

Instead, Mech abilities scale based on the type of Cap and Scanning Module. Capacitors add EMP resistance, 10% of it based on their level, and Scanning Modules reduce the power drain from movement by 5 per level .
