### PR TITLE
Workplace Accidents.

### DIFF
--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -128,7 +128,7 @@ var/const/tk_maxrange = 15
 
 	else
 		apply_focus_overlay()
-		focus.throw_at(target, 10, 1)
+		focus.throw_at(target, 10, 1,user)
 		last_throw = world.time
 	return
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -28,10 +28,10 @@
 	//Value used to increment ex_act() if reactionary_explosions is on
 	var/explosion_block = 0
 
-/atom/proc/throw_impact(atom/hit_atom)
+/atom/proc/throw_impact(atom/hit_atom,mob/thrower)
 	if(istype(hit_atom,/mob/living))
 		var/mob/living/M = hit_atom
-		M.hitby(src, ran_zone(throwzone, 50)) //50% chance to hit targeted limb
+		M.hitby(src,thrower)
 
 	else if(isobj(hit_atom))
 		var/obj/O = hit_atom

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -144,13 +144,13 @@
 /atom/movable/proc/checkpass(passflag)
 	return pass_flags&passflag
 
-/atom/movable/proc/hit_check() // todo: this is partly obsolete due to passflags already, add throwing stuff to mob CanPass and finish it
+/atom/movable/proc/hit_check(mob/thrower) // todo: this is partly obsolete due to passflags already, add throwing stuff to mob CanPass and finish it
 	if(src.throwing)
 		for(var/atom/A in get_turf(src))
 			if(A == src) continue
 			if(istype(A,/mob/living))
 				if(A:lying) continue
-				src.throw_impact(A)
+				src.throw_impact(A,thrower)
 				if(src.throwing == 1)
 					src.throwing = 0
 			if(isobj(A))
@@ -158,7 +158,7 @@
 					src.throw_impact(A)
 					src.throwing = 0
 
-/atom/movable/proc/throw_at(atom/target, range, speed)
+/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower)
 	if(!target || !src || (flags & NODROP))	return 0
 
 	//use a modified version of Bresenham's algorithm to get from the atom's current position to that of the target
@@ -205,7 +205,7 @@
 		if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
 			break
 		src.Move(step, get_dir(loc, step))
-		hit_check()
+		hit_check(thrower)
 		error += (error < 0) ? tdist_x : -tdist_y;
 		dist_travelled++
 		dist_since_sleep++

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -342,6 +342,16 @@
 		if (M.m_intent=="walk" && (lube&NO_SLIP_WHEN_WALKING))
 			return 0
 		if(!M.lying && (M.status_flags & CANWEAKEN) && !(HULK in M.mutations)) // we slip those who are standing and can fall.
+			if(O)
+				M << "<span class='notice'>You slipped on the [O.name]!</span>"
+			else
+				M << "<span class='notice'>You slipped!</span>"
+			M.attack_log += "\[[time_stamp()]\] <font color='orange'>Slipped[O ? " on the [O.name]" : ""][(lube&SLIDE)? " (LUBE)" : ""]!</font>"
+			playsound(M.loc, 'sound/misc/slip.ogg', 50, 1, -3)
+
+			M.accident(M.l_hand)
+			M.accident(M.r_hand)
+
 			var/olddir = M.dir
 			M.Stun(s_amount)
 			M.Weaken(w_amount)
@@ -353,11 +363,9 @@
 						M.spin(1,1)
 				if(M.lying) //did I fall over?
 					M.adjustBruteLoss(2)
-			if(O)
-				M << "<span class='notice'>You slipped on the [O.name]!</span>"
-			else
-				M << "<span class='notice'>You slipped!</span>"
-			playsound(M.loc, 'sound/misc/slip.ogg', 50, 1, -3)
+
+
+
 			return 1
 	return 0 // no success. Used in clown pda and wet floors
 

--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -269,6 +269,6 @@
 				holder.throw_atom = object
 			if(pa.Find("right"))
 				if(holder.throw_atom)
-					holder.throw_atom.throw_at(object, 10, 1)
+					holder.throw_atom.throw_at(object, 10, 1,user)
 					log_admin("Build Mode: [key_name(usr)] threw [holder.throw_atom] at [object] ([object.x],[object.y],[object.z])")
 

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -104,7 +104,7 @@
 	H.update_icon()
 
 	source.visible_message("\The [source] deals a card to \the [target].")
-	H.throw_at(get_step(target, target.dir), 10, 1, H)
+	H.throw_at(get_step(target, target.dir), 10, 1, source)
 
 /* Hand */
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -232,7 +232,7 @@
 
 		newtonian_move(get_dir(target, src))
 
-		item.throw_at(target, range, throw_speed)
+		item.throw_at(target, range, throw_speed, src)
 
 /mob/living/carbon/can_use_hands()
 	if(handcuffed)
@@ -382,3 +382,31 @@ var/const/GALOSHES_DONT_HELP = 8
 		return -6
 	else
 		return initial(pixel_y)
+
+/mob/living/carbon/proc/accident(var/obj/item/I)
+	if(!I || (I.flags & NODROP))
+		return
+
+	unEquip(I)
+
+	var/modifier = 0
+	if(disabilities & CLUMSY)
+		modifier -= 40 //Clumsy people are more likely to hit themselves -Honk!
+
+	switch(rand(1,100)+modifier) //91-100=Nothing special happens
+		if(-INFINITY to 0) //attack yourself
+			I.attack(src,src)
+		if(1 to 30) //throw it at yourself
+			I.throw_impact(src)
+		if(31 to 60) //Throw object in facing direction
+			var/turf/target = get_turf(loc)
+			var/range = rand(2,I.throw_range)
+			for(var/i = 1; i < range; i++)
+				var/turf/new_turf = get_step(target, dir)
+				target = new_turf
+				if(new_turf.density)
+					break
+			I.throw_at(target,I.throw_range,I.throw_speed,src)
+		if(61 to 90) //throw it down to the floor
+			var/turf/target = get_turf(loc)
+			I.throw_at(target,I.throw_range,I.throw_speed,src)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -35,7 +35,7 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 		else
 				return 0
 
-/mob/living/hitby(atom/movable/AM, zone)//Standardization and logging -Sieve
+/mob/living/hitby(atom/movable/AM, zone,mob/thrower)//Standardization and logging -Sieve
 	if(istype(AM, /obj/item))
 		if(!zone)
 			zone = ran_zone("chest", 65)
@@ -66,11 +66,8 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 		var/armor = run_armor_check(zone, "melee", "Your armor has protected your [parse_zone(zone)].", "Your armor has softened hit to your [parse_zone(zone)].")
 		apply_damage(I.throwforce, dtype, zone, armor, I)
 
-		if(I.fingerprintslast)
-			var/client/assailant = directory[ckey(I.fingerprintslast)]
-			if(assailant && assailant.mob && istype(assailant.mob,/mob))
-				var/mob/M = assailant.mob
-				add_logs(M, src, "hit", object="[I]")
+		if(thrower)
+			add_logs(thrower, src, "hit", object="[I]")
 
 /mob/living/mech_melee_attack(obj/mecha/M)
 	if(M.occupant.a_intent == "harm")

--- a/code/modules/reagents/grenade_launcher.dm
+++ b/code/modules/reagents/grenade_launcher.dm
@@ -51,7 +51,7 @@
 	var/obj/item/weapon/grenade/chem_grenade/F = grenades[1] //Now with less copypasta!
 	grenades -= F
 	F.loc = user.loc
-	F.throw_at(target, 30, 2)
+	F.throw_at(target, 30, 2,user)
 	message_admins("[key_name_admin(user)] fired a grenade ([F.name]) from a grenade launcher ([src.name]).")
 	log_game("[key_name(user)] fired a grenade ([F.name]) from a grenade launcher ([src.name]).")
 	F.active = 1

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -66,3 +66,34 @@
 
 			return 0
 	return 1
+
+/obj/item/weapon/reagent_containers/throw_impact(atom/target,mob/thrower)
+	..()
+
+	if(!reagents.total_volume || !is_open_container())
+		return
+
+	if(ismob(target) && target.reagents)
+		reagents.total_volume *= rand(5,10) * 0.1 //Not all of it makes contact with the target
+		var/mob/M = target
+		var/R
+		target.visible_message("<span class='danger'>[M] has been splashed with something!</span>", \
+						"<span class='userdanger'>[M] has been splashed with something!</span>")
+		if(reagents)
+			for(var/datum/reagent/A in reagents.reagent_list)
+				R += A.id + " ("
+				R += num2text(A.volume) + "),"
+
+		if(thrower)
+			add_logs(thrower, M, "splashed", object="[R]")
+		reagents.reaction(target, TOUCH)
+
+	else if(!target.density || target.throwpass)
+		if(thrower && thrower.mind && thrower.mind.assigned_role == "Bartender")
+			visible_message("<span class='notice'>[src] lands onto the [target.name] without spilling a single drop.</span>")
+			return
+
+	else
+		visible_message("<span class='notice'>[src] spills its contents all over [target].</span>")
+		reagents.reaction(target, TOUCH)
+	reagents.clear_reagents()

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -59,6 +59,7 @@ should be listed in the changelog upon commit tho. Thanks. -->
 	<h2 class='date'>28 September 2015</h2>
 	<h3 class='author'>Chronitonity updated:</h3>
 	<ul class='changes bgimages16'>
+		<li class='rscadd'>Slipping while carrying items now can cause accidents. Items may be flung or hit you, and containers with reagents in them will spill their contents.</li>
 		<li class='rscadd'>Skeletons are now a playable race.</li>
 	</ul>
 </div>


### PR DESCRIPTION
Ports workplace accidents from TG.

When slipping, new things can happen
30% to throw it at yourself
30% to throw it onto the floor under you
30% to throw the item towards the direction you're facing
Clumsy people like clowns  have chance of attacking themselves with the item

Thrown containers spills some of their contents onto what they hit, unless its thrown from the bartender.

Adds logs to slipping.
