### PR TITLE
Sticky ban sanity check.

### DIFF
--- a/code/modules/admin/stickyban.dm
+++ b/code/modules/admin/stickyban.dm
@@ -13,6 +13,8 @@
 
 			if (data["ckey"])
 				ckey = ckey(data["ckey"])
+				if(!ckey)
+					return
 			else
 				ckey = input(usr,"Ckey","Ckey","") as text|null
 				if (!ckey)


### PR DESCRIPTION
Adds a check for null/invalid ckeys. Should help reduce the amount of false bans being given by a ckey being added to the panel badly.
