### PR TITLE
Pneumatic cannons, guncase, wheelchair, deep fryers, revenant chat fixes

### DIFF
--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -71,6 +71,8 @@
 
 
 /obj/item/weapon/pneumatic_cannon/afterattack(atom/target as mob|obj|turf, mob/living/carbon/human/user as mob|obj, flag, params)
+	if(target in user.contents) // to avoid shooting yourself by putting this thing in the backpack
+		return
 	if(user.a_intent == "harm" || !ishuman(user))
 		return ..()
 	if(!loadedItems || !loadedWeightClass)

--- a/code/game/objects/structures/guncase.dm
+++ b/code/game/objects/structures/guncase.dm
@@ -27,8 +27,15 @@
 
 /obj/structure/guncase/update_icon()
 	overlays.Cut()
-	for(var/i = contents.len, i >= 1, i--)
-		overlays += image(icon = src.icon, icon_state = "[case_type]", pixel_x = 4 * (i -1) )
+	var/n = 4 //first line of guns overlay
+	var/m = 0 //second line of guns overlay
+	if(contents.len <= 4) n = contents.len
+	else m = contents.len-n
+	for(var/i in 1 to n)
+		overlays += image(icon = src.icon, icon_state = "[case_type]", pixel_x = 3 * (i-1) )
+	if(m)
+		for(var/i in 1 to m)
+			overlays += image(icon = src.icon, icon_state = "[case_type]", pixel_x = 3 * (i-1), pixel_y = 6)
 	if(open)
 		overlays += "[icon_state]_open"
 	else
@@ -44,21 +51,19 @@
 			contents += I
 			user << "<span class='notice'>You place [I] in [src].</span>"
 			update_icon()
+			interact(usr)
 			return
 
 	open = !open
 	update_icon()
 
 /obj/structure/guncase/attack_hand(mob/user)
-	if(isrobot(usr) || isalien(usr))
+	if(isrobot(user) || isalien(user))
 		return
-	if(contents.len && open)
-		ShowWindow(user)
-	else
-		open = !open
-		update_icon()
+	update_icon()
+	interact(user)
 
-/obj/structure/guncase/proc/ShowWindow(mob/user)
+/obj/structure/guncase/interact(mob/user)
 	var/dat = {"<div class='block'>
 				<h3>Stored Guns</h3>
 				<table align='center'>"}
@@ -74,14 +79,19 @@
 /obj/structure/guncase/Topic(href, href_list)
 	if(href_list["retrieve"])
 		var/obj/item/O = locate(href_list["retrieve"])
+		if(O.loc != src)
+			interact(usr)
+			return //safety check so you can't teleport guns
 		if(!usr.canUseTopic(src))
 			return
+		if(!open) return //safety check,don't just teleport junk out of a guncase if it's closed
 		if(ishuman(usr))
 			if(!usr.get_active_hand())
 				usr.put_in_hands(O)
 			else
 				O.loc = get_turf(src)
 			update_icon()
+			interact(usr)
 
 /obj/structure/guncase/shotgun
 	name = "shotgun locker"
@@ -95,3 +105,4 @@
 	icon_state = "ecase"
 	case_type = "egun"
 	gun_category = /obj/item/weapon/gun/energy
+	capacity = 7

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -206,6 +206,10 @@
 	spawn(4)
 		cooldown = 0
 
+/obj/structure/stool/bed/chair/wheelchair/rotate()
+	..()
+	handle_rotation()
+
 /obj/structure/stool/bed/chair/office/light
 	icon_state = "officechair_white"
 

--- a/code/modules/food&drinks/kitchen machinery/deep_fryer.dm
+++ b/code/modules/food&drinks/kitchen machinery/deep_fryer.dm
@@ -170,9 +170,11 @@
 			icon_state = "fryer_off"
 			on = FALSE
 			return
-		user << "<span class='notice'>You pull [O] from [src]! It looks like you were just in time!</span>"
-		user.put_in_hands(O)
-		icon_state = "fryer_off"
-		on = FALSE
+		else
+			var/obj/item/item = O
+			user << "<span class='notice'>You pull [item] from [src]! It looks like you were just in time!</span>"
+			item.loc = get_turf(src)
+			icon_state = "fryer_off"
+			on = FALSE
 		return
 	..()

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -155,7 +155,9 @@ var/list/possibleRevenantNames = list("Lust", "Gluttony", "Greed", "Sloth", "Wra
 
 /mob/living/simple_animal/revenant/say(message)
 	for(var/mob/M in mob_list)
-		if(istype(M, /mob/living/simple_animal/revenant) || M.stat == DEAD)
+		if(istype(M, /mob/new_player))
+			continue
+		if(istype(M, /mob/living/simple_animal/revenant)  || M.stat == DEAD)
 			M << "<span class='deadsay'><b>REVENANT: [src]</b> says, \"[message]\"" //Can commune with the dead
 	return
 

--- a/html/changelogs/Carbonhell-RevenantGuncaseetc.yml
+++ b/html/changelogs/Carbonhell-RevenantGuncaseetc.yml
@@ -1,0 +1,10 @@
+author: Carbonhell
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes pneumatic cannons shooting when you try to put them in the backpack."
+  - bugfix: "Fixes guncase spawning with guns on top of them, also energy ones can now hold 7 guns like before."
+  - bugfix: "Fixed rotating wheelchairs not rotating the mob too."
+  - bugfix: "Fixes a severe bug with deep fryers."
+  - bugfix: "Fixes revenant chat showing up to people in the lobby."


### PR DESCRIPTION
changes: 
- bugfix: "Fixes pneumatic cannons shooting when you try to put them in the backpack."
- bugfix: "Fixes guncase spawning with guns on top of them, also energy ones can now hold 7 guns like before."
- bugfix: "Fixed rotating wheelchairs not rotating the mob too."
- bugfix: "Fixes a severe bug with deep fryers."
- bugfix: "Fixes revenant chat showing up to people in the lobby."
  Fixes #1058
  Fixes #1053
  Fixes #1044
  Fixes #1041
  Fixes #1031
  Fixes #1062
