### PR TITLE
Now guncases in armory start closed, fixed an add_logs runtime, possibly fixes known embedding bug

### DIFF
--- a/code/game/objects/structures/guncase.dm
+++ b/code/game/objects/structures/guncase.dm
@@ -9,7 +9,7 @@
 	opacity = 0
 	var/case_type = null
 	var/gun_category = /obj/item/weapon/gun
-	var/open = 1
+	var/open = 0 // why would you make it start opened?like, why? there's literally zero reason, are you for real wtf
 	var/capacity = 4
 
 /obj/structure/guncase/New()
@@ -60,8 +60,10 @@
 /obj/structure/guncase/attack_hand(mob/user)
 	if(isrobot(user) || isalien(user))
 		return
-	update_icon()
-	interact(user)
+	if(!open)
+		open = 1
+		update_icon()
+	else interact(user)
 
 /obj/structure/guncase/interact(mob/user)
 	var/dat = {"<div class='block'>

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -318,7 +318,7 @@
 					src.anchored = 0
 					update_canmove()
 					I.pinned = null
-				usr.put_in_hands(I)
+				I.loc = get_turf(src)
 				I.add_fingerprint(usr)
 				src.emote("scream")
 				usr.visible_message("[usr] successfully rips [I] out of [usr == src ? "their" : "[src]'s"] [L.getDisplayName()]!","<span class='notice'>You successfully remove [I] from [usr == src ? "your" : "[src]'s"] [L.getDisplayName()].</span>")
@@ -749,7 +749,7 @@
 				src << "\t [status == "OK" ? "\blue" : "\red"] Your [org.getDisplayName()] is [status]."
 
 				for(var/obj/item/I in org.embedded_objects)
-					src << "\t <a href='byond://?src=\ref[src];embedded_object=\ref[I];embedded_limb=\ref[org]'>\red There is \a [I] embedded in your [org.getDisplayName()]! </a> [I.pinned ? "It has also pinned you down!" : ""] [istype(I, /obj/item/weapon/paper) ? "(<a href='byond://?src=\ref[org];read_embedded=\ref[I]'>Read</a>)" : ""]"
+					src << "\t <A href='byond://?src=\ref[src];embedded_object=\ref[I];embedded_limb=\ref[org]'>\red There is \a [I] embedded in your [org.getDisplayName()]! </A> [I.pinned ? "It has also pinned you down!" : ""] [istype(I, /obj/item/weapon/paper) ? "(<A href='byond://?src=\ref[org];read_embedded=\ref[I]'>Read</A>)" : ""]"
 
 			if(blood_max)
 				src << "<span class='danger'>You are bleeding!</span>"

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -94,7 +94,7 @@
 		for(var/datum/reagent/A in reagents.reagent_list)
 			R += A.id + " ("
 			R += num2text(A.volume) + "),"
-		if(assailant.mob) add_logs(assailant.mob, target, "splashed", object="[src]", addition="[R]")
+		if(assailant) add_logs(assailant.mob, target, "splashed", object="[src]", addition="[R]")
 
 		reagents.reaction(target, TOUCH)
 

--- a/html/changelogs/Carbonhell-Bugfixtwo.yml
+++ b/html/changelogs/Carbonhell-Bugfixtwo.yml
@@ -1,0 +1,7 @@
+author: Carbonhell
+
+delete-after: True
+
+changes: 
+  - tweak: "Gun cases in armory now start closed."
+  - bugfix: "Possibly fixes the known bug with embedding where an embedded item couldn't be removed in any way."


### PR DESCRIPTION
You can now open guncases with an open hand for consistency,plus they will start closed.
Fixed an add_logs runtime related to bottles being thrown by effects like singularity or sorium on mob. 
Possibly fixes the embedding issue where items couldn't be able to be removed, not 100% sure through since i cannot manage to reproduce the bug in local.
