### PR TITLE
Fixes a bug where you'd spawn with the nukecore obj and no kit

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -461,9 +461,15 @@ var/global/list/possible_items = list()
 	if(owner && owner.current && targetinfo)
 		if(istype(owner.current, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = owner.current
-			var/list/slots = list ("backpack" = slot_in_backpack)
+			var/list/slots = list (
+				"backpack" = slot_in_backpack,
+				"left hand" = slot_l_hand,
+				"right hand" = slot_r_hand,
+			)
 			for(var/obj/item/I in targetinfo.special_equipment)
-				H.equip_in_one_of_slots(I, slots)
+				var/equip = H.equip_in_one_of_slots(I, slots, qdel_on_fail = 0)
+				if(!equip) // if somehow it failed to put the special equip in your backpack/hands, put it under you. should never happen tho.
+					I.loc = get_turf(H)
 				H.update_icons()
 
 var/global/list/possible_items_special = list()


### PR DESCRIPTION
An admin reported that you could spawn with the traitor objective to steal the nuke core but without the box needed with screwdriver+container, so i added a safety check that puts it in your backpack,if no backpack it'll use hands,if there's no space either it'll spawn under you.
