### PR TITLE
Fixed emitters + some hotkey tweaks (Fixes 1123)

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -73,7 +73,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	var/deflectItem = 0 //For deflecting items thrown at you when you have throw intent on
 	var/mult = 0 //For code to reset throwforce back to normal after it hits something
 
-	/obj/item/mouse_drag_pointer = MOUSE_ACTIVE_POINTER //the icon to indicate this object is being dragged
+	mouse_drag_pointer = MOUSE_ACTIVE_POINTER //the icon to indicate this object is being dragged
 
 	//So items can have custom embedd values
 	//Because customisation is king

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -40,7 +40,7 @@
 	density = 0
 	mob_storage_capacity = 2
 	open_sound = 'sound/items/zip.ogg'
-
+	mouse_drag_pointer = MOUSE_ACTIVE_POINTER //Drag&Drop pointer indicating it's possible
 
 /obj/structure/closet/body_bag/attackby(obj/item/I, mob/user, params)
 	if (istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/toy/crayon))

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -42,6 +42,7 @@
 	icon_state = "down"
 	anchored = 0
 	burn_state = -1 //Not Burnable
+	mouse_drag_pointer = MOUSE_ACTIVE_POINTER //Drag&Drop pointer indicating it's possible
 
 /obj/structure/stool/bed/roller/post_buckle_mob(mob/living/M)
 	if(M == buckled_mob)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -158,7 +158,9 @@
 			src.shot_number = 0
 
 		var/obj/item/projectile/beam/emitter/A = PoolOrNew(/obj/item/projectile/beam/emitter,src.loc)
-
+		//Legacy mode since this projectile doesn't really need pixel travelling.
+		A.legacy = 1 //No pixel travelling
+		A.animate_movement = SLIDE_STEPS //Reset movement to default
 		A.dir = src.dir
 		playsound(src.loc, 'sound/weapons/emitter.ogg', 25, 1)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -143,6 +143,7 @@
 
 
 /obj/item/projectile/proc/fire(var/setAngle)
+	bumped = 0 //We're fired, so let's reset bumped variable (this is for projectiles that are PoolOrNew'ed like emitter beams.)
 	if(setAngle) Angle = setAngle
 	if(!legacy)
 		spawn() //New projectile system

--- a/html/changelogs/Crystalwarrior160 - fooxes.yml
+++ b/html/changelogs/Crystalwarrior160 - fooxes.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Crystalwarrior160
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added new keybind for resting. Ctrl + C or C in hotkey mode will make you rest!"
+  - rscdel: "Removed the hotkey mode OOC keybind 'O' (didn't touch 'Ctrl+O'). It caused too much accidental IC OOC and was frankly unneccesary."
+  - bugfix: "Fixed emitter beams not hitting the shield generators."
+  - tweak: "Added 'drag and drop' mouse pointer to bodybags and rollerbeds to help indicate that they can be dragged&dropped."

--- a/html/changelogs/Crystalwarrior160 - fooxes.yml
+++ b/html/changelogs/Crystalwarrior160 - fooxes.yml
@@ -34,6 +34,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "Added new keybind for resting. Ctrl + C or C in hotkey mode will make you rest!"
-  - rscdel: "Removed the hotkey mode OOC keybind 'O' (didn't touch 'Ctrl+O'). It caused too much accidental IC OOC and was frankly unneccesary."
   - bugfix: "Fixed emitter beams not hitting the shield generators."
   - tweak: "Added 'drag and drop' mouse pointer to bodybags and rollerbeds to help indicate that they can be dragged&dropped."

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -132,10 +132,6 @@ macro "borghotkeymode"
 		command = "a-intent right"
 		is-disabled = false
 	elem 
-		name = "O"
-		command = "ooc"
-		is-disabled = false
-	elem 
 		name = "CTRL+O"
 		command = "ooc"
 		is-disabled = false
@@ -572,8 +568,8 @@ macro "hotkeymode"
 		command = "me"
 		is-disabled = false
 	elem 
-		name = "O"
-		command = "ooc"
+		name = "C"
+		command = "rest"
 		is-disabled = false
 	elem 
 		name = "CTRL+O"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -572,6 +572,10 @@ macro "hotkeymode"
 		command = "rest"
 		is-disabled = false
 	elem 
+		name = "CTRL+C"
+		command = "rest"
+		is-disabled = false
+	elem 
 		name = "CTRL+O"
 		command = "ooc"
 		is-disabled = false

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -132,6 +132,10 @@ macro "borghotkeymode"
 		command = "a-intent right"
 		is-disabled = false
 	elem 
+		name = "O"
+		command = "ooc"
+		is-disabled = false
+	elem
 		name = "CTRL+O"
 		command = "ooc"
 		is-disabled = false
@@ -574,6 +578,10 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+C"
 		command = "rest"
+		is-disabled = false
+	elem
+		name = "O"
+		command = "ooc"
 		is-disabled = false
 	elem 
 		name = "CTRL+O"


### PR DESCRIPTION
- "Added new keybind for resting. Ctrl + C or C in hotkey mode will make you rest!"
- ~~"Removed the hotkey mode OOC keybind 'O' (didn't touch 'Ctrl+O'). It caused too much accidental IC OOC and was frankly unneccesary."~~
- "Fixed emitter beams not hitting the shield generators."
- "Added 'drag and drop' mouse pointer to bodybags and rollerbeds to help indicate that they can be dragged&dropped."
