### PR TITLE
People in neckgrab will only fall over if in crit/unconscious/dead

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -776,6 +776,11 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/update_canmove()
 	var/ko = weakened || paralysis || stat || (status_flags & FAKEDEATH)
 	var/buckle_lying = !(buckled && !buckled.buckle_lying)
+	var/grabbed = 0 //Search for grabs within src
+	for(var/obj/item/weapon/grab/G in grabbed_by)
+		if(G.assailant && G.state >= GRAB_NECK && G.affecting == src)
+			grabbed = 1
+			break
 	if(ko || resting || stunned)
 		drop_r_hand()
 		drop_l_hand()
@@ -786,6 +791,8 @@ var/list/slot_equipment_priority = list( \
 		lying = 90*buckle_lying
 	else if(pinned_to)
 		lying = 0
+	else if(grabbed) //Hostage hold -- the meatshield will only fall down if they're incapacitated/unconscious/dead
+		lying = nearcrit || stat || (status_flags & FAKEDEATH) 
 	else
 		if((ko || resting) && !lying)
 			fall(ko)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -792,7 +792,7 @@ var/list/slot_equipment_priority = list( \
 	else if(pinned_to)
 		lying = 0
 	else if(grabbed) //Hostage hold -- the meatshield will only fall down if they're incapacitated/unconscious/dead
-		lying = nearcrit || stat || (status_flags & FAKEDEATH) 
+		lying = 90*(nearcrit || stat || (status_flags & FAKEDEATH))
 	else
 		if((ko || resting) && !lying)
 			fall(ko)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -388,6 +388,7 @@
 		affecting.pixel_x = 0
 		affecting.pixel_y = 0 //used to be an animate, not quick enough for del'ing
 		affecting.layer = initial(affecting.layer)
+		affecting.update_canmove()
 	// qdel(hud)
 	..()
 
@@ -397,6 +398,7 @@
 		affecting.pixel_y = 0 //used to be an animate, not quick enough for del'ing
 		affecting.layer = initial(affecting.layer)
 		affecting.grabbed_by -= src
+		affecting.update_canmove()
 	// qdel(hud)
 	..()
 


### PR DESCRIPTION
Suggested feature on Trello, makes meatshields much more practical.
