### PR TITLE
Power fist rework (code optimization, some balancing improvements)

### DIFF
--- a/html/changelogs/DerptheStewpidGoat-PowerfistRework.yml
+++ b/html/changelogs/DerptheStewpidGoat-PowerfistRework.yml
@@ -1,0 +1,15 @@
+# Your name.  
+author: DerptheStewpidgoat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Power fist code changed greatly to make it perform better to cause less lag on the server."
+  - tweak: "Power fist cooldown has been readded BUT it uses a different system so that rather than having a random 0 - 2 second cooldown which was very unreliable you now only have a slightly-longer-than-normal cooldown which is practically always the same. New cool-down system also lets admins set the cooldown to literally 0 so they can pulverize someone as fast as they can click."
+  - tweak: "Power fist now takes armor into account and no longer does stamina damage but can punch through any kind of window or grille instantly. Power fist cost has NOT been changed."


### PR DESCRIPTION
- tweak: "Power fist code changed greatly to make it perform better to
  cause less lag on the server."
- tweak: "Power fist cooldown has been readded BUT it uses a different
  system so that rather than having a random 0 - 2 second cooldown which
  was very unreliable you now only have a slightly-longer-than-normal
  cooldown which is practically always the same. New cool-down system also
  lets admins set the cooldown to literally 0 so they can pulverize
  someone as fast as they can click."
- tweak: "Power fist now takes armor into account and no longer does
  stamina damage but can punch through any kind of window or grille
  instantly. Power fist cost has NOT been changed."
