### PR TITLE
Zombie balance tweaks and bugfixes

### DIFF
--- a/code/datums/diseases/zombie.dm
+++ b/code/datums/diseases/zombie.dm
@@ -39,15 +39,15 @@ var/list/zombie_cure = list()
 
 /datum/disease/transformation/zombie/do_disease_transformation(mob/living/carbon/affected_mob)
 	if(affected_mob.notransform) return
-	affected_mob.death()
 	affected_mob.notransform = 1
-	sleep(30)
+	affected_mob.emote("faint")
+	spawn(30)
+		Zombify(affected_mob)
 	cure()
-	Zombify(affected_mob)
 
-/datum/disease/transformation/zombie/cure()
-	ticker.mode.remove_zombie(affected_mob.mind)
-	..()
+// /datum/disease/transformation/zombie/cure()
+// 	ticker.mode.remove_zombie(affected_mob.mind) //Unneeded, infected people aren't considered antags until transformation
+// 	..()
 
 /datum/disease/transformation/zombie/has_cure()
 	if(affected_mob.stat == DEAD) //Cure won't work if the disease holder is already dead. The only thing to do now is to get rid of the corpse.

--- a/code/datums/diseases/zombie.dm
+++ b/code/datums/diseases/zombie.dm
@@ -13,7 +13,7 @@ var/list/zombie_cure = list()
 	longevity = 30
 	desc = "Humans infected with this disease eventually will become a zombie that will spread the disease via biting."
 	severity = BIOHAZARD
-	stage_prob = 3
+	stage_prob = 4
 	visibility_flags = HIDDEN_SCANNER
 	agent = "Z-Virus Beta"
 
@@ -39,7 +39,7 @@ var/list/zombie_cure = list()
 
 /datum/disease/transformation/zombie/do_disease_transformation(mob/living/carbon/affected_mob)
 	if(affected_mob.notransform) return
-	affected_mob.death(1)
+	affected_mob.death()
 	affected_mob.notransform = 1
 	sleep(30)
 	cure()
@@ -73,12 +73,12 @@ var/list/zombie_cure = list()
 				else if(prob(5))
 					if(ishuman(affected_mob))
 						var/mob/living/carbon/human/H = affected_mob
-						H.vessel.remove_reagent("blood",rand(1,5))
+						H.vessel.remove_reagent("blood",rand(1,3))
 					affected_mob.visible_message("<span class='warning'>[affected_mob] looks a bit pale...</span>", "<span class='notice'>You look a bit pale...</span>")
 			if(4)
 				if(ishuman(affected_mob))
 					var/mob/living/carbon/human/H = affected_mob
-					H.vessel.remove_reagent("blood",rand(1,2))
+					H.vessel.remove_reagent("blood",rand(1,5))
 				if(prob(15))
 					affected_mob << "<span class='notice'>[pick("You feel hot.", "You feel like you're burning.")]</span>"
 					if(affected_mob.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT)
@@ -90,3 +90,6 @@ var/list/zombie_cure = list()
 					affected_mob.visible_message("<span class='warning'>[affected_mob] looks very pale...</span>", "<span class='notice'>You look very pale...</span>")
 				else if(prob(7))
 					affected_mob.emote(pick("cough", "sneeze", "groan", "gasp"))
+	else
+		if(prob(stage_prob)) //DOUBLE the probability to mutate when dead
+			stage = min(stage+1, max_stages)

--- a/code/game/gamemodes/zombie/zombie.dm
+++ b/code/game/gamemodes/zombie/zombie.dm
@@ -8,7 +8,7 @@
 
 	required_players = 20
 	required_enemies = 1
-	recommended_enemies = 1
+	recommended_enemies = 2
 
 	restricted_jobs = list("Cyborg", "AI")
 
@@ -17,14 +17,13 @@
 	var/carriers_to_make = 1
 	var/list/carriers = list()
 
-	var/zombies_to_win = 0
 	var/live_zombies = 0
 
-	var/players_per_carrier = 13 //1 patient zero every 13 players
+	var/players_per_carrier = 11 //1 patient zero every 13 players
 
+//Uncomment if you want zombie gamemode to be strictly mulligan
 /datum/game_mode/zombie/can_start()
-	return 0 //Zombie gamemodes are strictly mulligan
-	// ..()
+	return 0
 
 /datum/game_mode/zombie/pre_setup()
 	carriers_to_make = max(round(num_players()/players_per_carrier, 1), 1)
@@ -88,7 +87,7 @@
 	for(var/mob/living/simple_animal/hostile/zombie in living_mob_list)
 		if(zombie.stat != DEAD)
 			live_zombies++
-	if(live_zombies >= zombies_to_win)
+	if(live_zombies >= (num_players() * 0.8)) //80% of the crew infected
 		return 1
 	else
 		return 0

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -639,7 +639,7 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	say_mod = "moans"
 	sexes = 0
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/zombie
-	specflags = list(NOBREATH,HEATRES,COLDRES,NOBLOOD,RADIMMUNE)
+	// specflags = list(NOBREATH,HEATRES,COLDRES,NOBLOOD,RADIMMUNE) //Overpowered, and simple_mobs set the species to this
 
 /datum/species/zombie/handle_speech(message)
 	var/list/message_list = text2list(message, " ")

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -103,18 +103,15 @@
 /mob/living/simple_animal/hostile/zombie/death()
 	..()
 	if(stored_corpse)
-		stored_corpse.loc = loc
-		if(ckey)
-			stored_corpse.ckey = src.ckey //This can potentially let ghosts get cloned from a zombie corpse
+		stored_corpse.loc = get_turf(src)
+		// if(ckey)
+		// 	stored_corpse.key = src.key //This is VERY broken.
 		qdel(src)
 		return
 
 /proc/Zombify(mob/living/carbon/human/H)
 	if(!istype(H)) return
-	H.update_canmove()
 	H.set_species(/datum/species/zombie)
-	if(!H.stat)
-		H.death()
 	ticker.mode.add_zombie(H.mind)
 	for(var/mob/dead/observer/ghost in player_list)
 		if(H.real_name == ghost.real_name)
@@ -130,7 +127,8 @@
 	Z.appearance = H.appearance
 	Z.transform = matrix()
 	Z.pixel_y = 0
-	H.stat = DEAD
+	if(H.stat != DEAD)
+		H.death(0)
 	H.loc = Z
 	Z.original_corpse_ckey = H.ckey
 	Z.stored_corpse = H

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -22,15 +22,15 @@
 	minbodytemp = 0
 	maxbodytemp = 350
 	unsuitable_atmos_damage = 10
-	environment_smash = 1
+	environment_smash = 1 //Can smash tables and lockers, etc.
 	can_force_doors = 1 //Can force doors open like a champ
 	robust_searching = 1
-	stat_attack = 1
+	stat_attack = 1 //Can attack unconscious players
 	gold_core_spawnable = 0 //No.
 	faction = list("zombie")
 	languages = ZOMBIE
 
-	var/infection = 20 //Chance of infecting the victim.
+	var/infection = 25 //Chance of infecting the victim.
 	var/mob/living/carbon/human/stored_corpse = null
 	var/original_corpse_ckey = null
 
@@ -54,6 +54,9 @@
 	if(ckey && client)
 		user << "The zombie is already controlled by a player."
 		return
+	if(stat)
+		user << "The zombie is dead!"
+		return
 	var/be_zombie = alert("Become a zombie? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(be_zombie == "No")
 		return
@@ -67,11 +70,11 @@
 
 /mob/living/simple_animal/hostile/zombie/Login()
 	..()
-	src << "<b>You have transformed into a Zombie. You exist only for one purpose: to spread the infection.</b>"
-	src << "<b>Clicking on the doors will let you force-open them. Time taken depends on if the door is bolted, welded or both.</b>"
-	src << "<b>Clicking on animal corpses will make you feast on them, restoring your health.</b>"
-	src << "<b>You will spread the infection through BITES. they have a random chance of happening when you attack a human being.</b>"
-	src << "<b>The zombie disease will make zombies even out of dead humans, but you can only spread it to living humans. Therefore it's not important to keep your victims alive.</b>"
+	src << "<b><font size = 3><font color = red>You have transformed into a Zombie. You exist only for one purpose: to spread the infection.</font color></font size></b>"
+	src << "Clicking on the doors will let you <b>force-open</b> them. Time taken depends on if the door is bolted, welded or both."
+	src << "Clicking on animal corpses will make you <b>feast</b> on them, restoring your health."
+	src << "You will spread the infection through <b>bites</b>. they have a random chance of happening when you attack a human being."
+	src << "The zombie disease will make zombies <b>even out of dead humans</b>, but you can only <b>spread it to living humans</b>. Therefore it's not important to keep your victims alive."
 
 /mob/living/simple_animal/hostile/zombie/AttackingTarget()
 	if(istype(target, /mob/living))
@@ -86,12 +89,12 @@
 			playsound(loc, 'sound/weapons/slice.ogg', 50, 1, -1)
 			visible_message("<span class='danger'>[src] begins consuming [L]!</span>",\
 							"<span class='userdanger'>You begin feasting on [L]...</span>")
-			if(do_mob(src, L, 80))
+			if(do_mob(src, L, 60))
 				visible_message("<span class='danger'>[src] tears [L] to pieces!</span>",\
 								"<span class='userdanger'>You feast on [L], restoring your health!</span>")
 				L.gib()
 				src.revive()
-				return
+			return
 
 	target.attack_animal(src)
 	attacktext = "claws"
@@ -108,9 +111,10 @@
 
 /proc/Zombify(mob/living/carbon/human/H)
 	if(!istype(H)) return
-	H.death(1)
 	H.update_canmove()
 	H.set_species(/datum/species/zombie)
+	if(!H.stat)
+		H.death()
 	ticker.mode.add_zombie(H.mind)
 	for(var/mob/dead/observer/ghost in player_list)
 		if(H.real_name == ghost.real_name)

--- a/html/changelogs/Crystalwarrior160 - zombomb.yml
+++ b/html/changelogs/Crystalwarrior160 - zombomb.yml
@@ -1,0 +1,7 @@
+author: Crystalwarrior160
+delete-after: True
+changes: 
+  - bugfix: "Fixed zombies appearing standing up on death."
+  - tweak: "Increased zombie infection chance, made zombie disease twice as fast if the infectee is dead."
+  - tweak: "Reduced time taken to consume animals from 8 seconds to 6 seconds."
+  - tweak: "Updated zombie antag info formatting to be more visible."


### PR DESCRIPTION
-  - bugfix: "Fixed zombies appearing standing up on death."
-  - tweak: "Increased zombie infection chance, made zombie disease twice as fast if the infectee is dead."
-  - tweak: "Reduced time taken to consume animals from 8 seconds to 6 seconds."
-  - tweak: "Updated zombie antag info formatting to be more visible."
