### PR TITLE
Hub forums link update

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -203,7 +203,7 @@
 	if (config && config.server_name)
 		s += "<b>[config.server_name]</b> &#8212; "
 
-	s += "<h2><b><a href=\"http://hippie-station-13.com\">[station_name()]</a></b></h2>"
+	s += "<h2><b><a href=\"[config.forumurl]\">[station_name()]</a></b></h2>"
 
 	var/list/features = list()
 


### PR DESCRIPTION
The hub forums link now uses the forum URL, rather than being hardcoded within the anchor tag.
