### PR TITLE
Projectile bugfixes + screen flash no longer prevents all interaction

### DIFF
--- a/code/_onclick/hud/alien.dm
+++ b/code/_onclick/hud/alien.dm
@@ -142,6 +142,7 @@
 	mymob.flash.name = "flash"
 	mymob.flash.screen_loc = "WEST,SOUTH to EAST,NORTH"
 	mymob.flash.layer = 17
+	mymob.flash.mouse_opacity = 0
 
 	mymob.zone_sel = new /obj/screen/zone_sel/alien()
 	mymob.zone_sel.icon = 'icons/mob/screen_alien.dmi'

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -46,6 +46,7 @@
 	mymob.flash.name = "flash"
 	mymob.flash.screen_loc = "WEST,SOUTH to EAST,NORTH"
 	mymob.flash.layer = 17
+	mymob.flash.mouse_opacity = 0
 
 	mymob.zone_sel = new /obj/screen/zone_sel/alien()
 	mymob.zone_sel.icon = 'icons/mob/screen_alien.dmi'

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -306,6 +306,7 @@
 	mymob.flash.blend_mode = BLEND_ADD
 	mymob.flash.screen_loc = "WEST,SOUTH to EAST,NORTH"
 	mymob.flash.layer = 17
+	mymob.flash.mouse_opacity = 0
 
 	mymob.zone_sel = new /obj/screen/zone_sel()
 	mymob.zone_sel.icon = ui_style

--- a/code/_onclick/hud/monkey.dm
+++ b/code/_onclick/hud/monkey.dm
@@ -137,6 +137,7 @@
 	mymob.flash.name = "flash"
 	mymob.flash.screen_loc = "WEST,SOUTH to EAST,NORTH"
 	mymob.flash.layer = 17
+	mymob.flash.mouse_opacity = 0
 
 	mymob.zone_sel = new /obj/screen/zone_sel()
 	mymob.zone_sel.icon = ui_style

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -158,6 +158,7 @@
 	mymob.flash.name = "flash"
 	mymob.flash.screen_loc = "WEST,SOUTH to EAST,NORTH"
 	mymob.flash.layer = 17
+	mymob.flash.mouse_opacity = 0
 
 	mymob.zone_sel = new /obj/screen/zone_sel()
 	mymob.zone_sel.icon = 'icons/mob/screen_cyborg.dmi'

--- a/code/modules/projectiles/guns/projectile/rodgun.dm
+++ b/code/modules/projectiles/guns/projectile/rodgun.dm
@@ -23,6 +23,7 @@
 	projectile_type = /obj/item/projectile/rod
 
 /obj/item/projectile/rod/on_hit(atom/target, blocked = 0, hit_zone)
+	..()
 	if(ismob(target))
 		playsound(target, 'sound/weapons/rodgun_pierce.ogg', 50, 1)
 		if(ishuman(target))

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -131,10 +131,8 @@ obj/item/projectile/kinetic/New()
 	..()
 
 /obj/item/projectile/kinetic/Range()
-	range--
-	if(range <= 0)
-		new /obj/item/effect/kinetic_blast(src.loc)
-		qdel(src)
+	new /obj/item/effect/kinetic_blast(src.loc)
+	..()
 
 /obj/item/projectile/kinetic/on_hit(atom/target)
 	. = ..()

--- a/html/changelogs/Crystalwarrior160 - projk.yml
+++ b/html/changelogs/Crystalwarrior160 - projk.yml
@@ -1,0 +1,5 @@
+author: Crystalwarrior160
+delete-after: True
+changes: 
+  - tweak: "Makes screen flash mouse-opaque so you can still shoot/interact with objects while flashed. Solves the issue where you literally couldn't shoot or defend yourself in any way when flashed."
+  - bugfix: "Overhaul to projectile.dm - made projectiles density 0, reworked Bump proc, simplified range procs. This means that projectiles won't randomly miss you in most cases where they did, and means projectiles won't randomly hit you when they shouldn't. Thanks to /tg/ for most of these."


### PR DESCRIPTION
- tweak: "Makes screen flash mouse-opaque so you can still shoot/interact with objects while flashed. Solves the issue where you literally couldn't shoot or defend yourself in any way when flashed."
- bugfix: "Overhaul to projectile.dm - made projectiles density 0, reworked Bump proc, simplified range procs. This means that projectiles won't randomly miss you in most cases where they did, and means projectiles won't randomly hit you when they shouldn't. Thanks to /tg/ for most of these.
