### PR TITLE
Misc. fixes and tweaks

### DIFF
--- a/code/datums/spells/conjure.dm
+++ b/code/datums/spells/conjure.dm
@@ -16,7 +16,7 @@
 	var/cast_sound = 'sound/items/welder.ogg'
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/cast(list/targets)
-	playsound(get_turf(usr), cast_sound, 50,1)
+	playsound(get_turf(usr), get_sfx(cast_sound), 50,1)
 	for(var/turf/T in targets)
 		if(T.density && !summon_ignore_density)
 			targets -= T

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -104,13 +104,13 @@
 	gender = PLURAL
 	singular_name = "medical gauze"
 	icon_state = "gauze"
-	stop_bleeding = 1800
+	stop_bleeding = 3000 //5 mins
 
 /obj/item/stack/medical/gauze/improvised
 	name = "improvised gauze"
 	singular_name = "improvised gauze"
 	desc = "A roll of cloth roughly cut from something that can stop bleeding, but does not heal wounds."
-	stop_bleeding = 900
+	stop_bleeding = 1500 // 2.5 mins
 
 /obj/item/stack/medical/gauze/cyborg/
 	materials = list()

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -27,8 +27,6 @@
 	desc = "A light and compact fibreglass-framed model fire extinguisher."
 	icon_state = "miniFE0"
 	item_state = "miniFE"
-	hitsound = null	//it is much lighter, after all.
-	flags = null //doesn't CONDUCT
 	throwforce = 2
 	w_class = 2
 	force = 3

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -1,6 +1,10 @@
 /mob/living/carbon/human
 	languages = HUMAN
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD,ANTAG_HUD)
+
+	crit_can_crawl = 1
+	crit_crawl_damage = 1 //Crawling in crit should apply 1 oxyloss
+	crit_crawl_damage_type = OXY //Just in case
 	//Hair colour and style
 	var/hair_color = "000"
 	var/hair_style = "Bald"

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -12,6 +12,9 @@
 	type_of_meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/monkey
 	gib_type = /obj/effect/decal/cleanable/blood/gibs
 	unique_name = 1
+	crit_can_crawl = 1 //Can crawl in crit
+	crit_crawl_damage = 1 //Crawling in crit should apply 1 oxyloss
+	crit_crawl_damage_type = OXY //Just in case
 
 /mob/living/carbon/monkey/New()
 	verbs += /mob/living/proc/mob_sleep

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -166,8 +166,8 @@
 		I.action.Grant(src)
 
 	if(recursive)
-		for(var/obj/item/T in I)
-			give_action_button(I, recursive - 1)
+		for(var/obj/item/U in I)
+			give_action_button(U, recursive - 1)
 
 
 //this handles hud updates. Calls update_vision() and handle_hud_icons()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -161,3 +161,6 @@
 	var/resize = 1 //Badminnery resize
 
 	var/nearcrit = 0 //for newcrit
+	var/crit_can_crawl = 0 //whether or not the mob can crawl in crit
+	var/crit_crawl_damage = 0 //No damage by default
+	var/crit_crawl_damage_type = OXY

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -165,10 +165,11 @@
 				move_delay += config.walk_speed
 		move_delay += mob.movement_delay()
 
-		if(mob.nearcrit) //You can only crawl in nearcrit
+		if(mob.nearcrit && mob.crit_can_crawl) //You can only crawl in nearcrit
 			if(istype(mob, /mob/living))
 				var/mob/living/L = mob
-				L.adjustOxyLoss(1)
+				if(mob.crit_crawl_damage != 0) // let 'em have their negative values
+					L.apply_damage(mob.crit_crawl_damage, mob.crit_crawl_damage_type)
 			if(mob.dir == WEST)
 				mob.lying = 270
 				mob.update_canmove()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -412,7 +412,7 @@
 
 	semicd = 1
 
-	if(!do_mob(user, target, 120) || user.zone_sel.selecting != "mouth")
+	if(!do_mob(user, target, 120, numticks = 60) || user.zone_sel.selecting != "mouth") //60 ticks for 120 time, means it checks adjacency every 2 secs
 		if(user)
 			if(user == target)
 				user.visible_message("<span class='notice'>[user] decided life was worth living.</span>")

--- a/code/modules/surgery/dental_surgeries.dm
+++ b/code/modules/surgery/dental_surgeries.dm
@@ -107,32 +107,24 @@
 	O.dentals += pill
 	pill.loc = O
 
-	var/datum/action/item_action/hands_free/activate_pill/P = new
-	P.button_icon_state = pill.icon_state
-	P.target = pill
-	P.Grant(target)
+	pill.action_button_is_hands_free = 1
+	pill.action_button_name = "burst [pill]"
+	target.give_action_button(pill)
+	pill.action.button_icon_state = pill.icon_state
 
 	user.visible_message("[user] wedges [pill] into [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You wedge [pill] into [target]'s [parse_zone(target_zone)].</span>")
 	return 1
 
-/datum/action/item_action/hands_free/activate_pill
-	name = "activate pill"
-
-/datum/action/item_action/hands_free/activate_pill/Trigger()
-	if(CheckRemoval(owner))
-		return 0
-	var/obj/item/weapon/reagent_containers/food/drinks/P = target //Pill
-	if(ishuman(owner) && istype(P))
-		var/mob/living/carbon/human/H = owner
+/obj/item/weapon/reagent_containers/pill/ui_action_click()
+	if(ishuman(usr))
+		var/mob/living/carbon/human/H = usr
 		var/obj/item/organ/limb/head/O = locate(/obj/item/organ/limb/head) in H.organs
 		if(!O || !O.get_teeth())
-			H << "<span class='caution'>You have no teeth to burst \the [P]!</span>"
-			return 0
-		H << "<span class='caution'>You grit your teeth and burst the implanted [P]!</span>"
-		add_logs(owner, H, "bursted the implanted", P.reagentlist(P))
-		if(P.reagents.total_volume)
-			P.reagents.reaction(H, INGEST)
-			P.reagents.trans_to(H, P.reagents.total_volume)
-		qdel(P)
-		return 1
-	return 0
+			H << "<span class='caution'>You have no teeth to burst \the [src]!</span>"
+			return
+		H << "<span class='caution'>You grit your teeth and burst the implanted [src]!</span>"
+		add_logs(usr, object=src, what_done="bursted the implanted", addition=src.reagentlist(src))
+		if(reagents && reagents.total_volume)
+			reagents.reaction(H, INGEST)
+			reagents.trans_to(H, reagents.total_volume)
+		qdel(src)

--- a/html/changelogs/Crystalwarrior160 - miscshit.yml
+++ b/html/changelogs/Crystalwarrior160 - miscshit.yml
@@ -1,0 +1,10 @@
+author: Crystalwarrior160
+delete-after: True
+changes: 
+  - tweak: "Increased num of ticks for sticking gun in people's mouths so you're not fucked over for a long time if you do it in combat accidentaly or something."
+  - tweak: "Increased medical gauze effectiveness, including the improvised gauze. Now medical gauze stops bleeding for 5 mins when makeshift does it for 2.5 mins."
+  - bugfix: "Fixed null sounds stopping all sounds for conjure spells"
+  - bugfix: "Fixed pocket fire extinguisher not having a hitsound"
+  - bugfix: "Fixed aliens and other mobs being able to 'crit crawl' where it would rapidly drain their oxyloss. Fixes alien crit."
+  - bugfix: "Fixed dental implants"
+  - bugfix: "Fixed a bug with recursive checks for items inside items that may contain action buttons (fixes internal jetpacks that exist in hardsuits)"


### PR DESCRIPTION
Increased num of ticks for sticking gun in people's mouths so you're not fucked over for a long time if you do it in combat accidentaly or something.
Increased medical gauze effectiveness, including the improvised gauze. Now medical gauze stops bleeding for 5 mins when makeshift does it for 2.5 mins.
Fixed null sounds stopping all sounds for conjure spells
Fixed pocket fire extinguisher not having a hitsound
Fixed aliens and other mobs being able to "crit crawl" where it would rapidly drain their oxyloss. Fixes alien crit.
Fixed dental implants
Fixed a bug with recursive checks for items inside items that may contain action buttons (fixes internal jetpacks that exist in hardsuits)
