### PR TITLE
Noose fixes

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -458,7 +458,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 	new/datum/stack_recipe("cable restraints", /obj/item/weapon/restraints/handcuffs/cable, 15), \
-	new/datum/stack_recipe("noose", /obj/structure/noose, 30, time = 10, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("noose", /obj/structure/noose, 30, time = 100, one_per_turf = 1, on_floor = 1), \
 	)
 
 /obj/item/stack/cable_coil
@@ -505,8 +505,8 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 
 /obj/item/stack/cable_coil/building_checks(datum/stack_recipe/R, multiplier)
 	if(R.title == "noose")
-		if(!(locate(/obj/structure/stool) in user.loc) && !(locate(/obj/structure/table) in user.loc) && !(locate(/obj/structure/toilet) in user.loc))
-			user << "<span class='warning'>You have to be standing on top of a chair/table/toilet to make a noose!</span>"
+		if(!(locate(/obj/structure/stool) in usr.loc) && !(locate(/obj/structure/table) in usr.loc) && !(locate(/obj/structure/toilet) in usr.loc))
+			usr << "<span class='warning'>You have to be standing on top of a chair/table/toilet to make a noose!</span>"
 			return 0
 	return ..()
 
@@ -544,6 +544,7 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 	can_buckle = 1
 	burn_state = 0 //Burnable
 	burntime = 30
+	layer = 5
 	var/image/over = null
 	var/ticks = 0
 
@@ -613,6 +614,7 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 /obj/structure/noose/user_buckle_mob(mob/living/M, mob/user)
 	if(!in_range(user, src) || user.stat || user.restrained() || !iscarbon(M))
 		return 0
+	if(M.loc != src.loc) return 0 //Can only noose someone if they're on the same tile as noose
 
 	add_fingerprint(user)
 
@@ -620,6 +622,8 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 		M.visible_message(\
 			"<span class='suicide'>[M] ties \the [src] over their neck!</span>",\
 			"<span class='suicide'>You tie \the [src] over your neck!</span>")
+		playsound(user.loc, 'sound/effects/noosed.ogg', 50, 1, -1)
+		add_logs(user, "", "hanged themselves", src)
 		return 1
 	else
 		M.visible_message(\
@@ -631,8 +635,14 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 				M.visible_message(\
 					"<span class='danger'>[user] ties \the [src] over [M]'s neck!</span>",\
 					"<span class='userdanger'>[user] ties \the [src] over your neck!</span>")
+				playsound(user.loc, 'sound/effects/noosed.ogg', 50, 1, -1)
+				add_logs(user, M, "hanged", src)
 				return 1
 			else
+				user.visible_message(\
+					"<span class='warning'>[user] fails to tie \the [src] over [M]'s neck!</span>",\
+					"<span class='warning'>You fail to tie \the [src] over [M]'s neck!</span>")
+				return 0
 		else
 			user.visible_message(\
 				"<span class='warning'>[user] fails to tie \the [src] over [M]'s neck!</span>",\
@@ -651,8 +661,8 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 			pixel_x -= 1
 			buckled_mob.pixel_x -= 1
 		if(2)
-			pixel_x += 1
-			buckled_mob.pixel_x += 1
+			pixel_x = initial(pixel_x)
+			buckled_mob.pixel_x = initial(buckled_mob.pixel_x)
 		if(3) //Every third tick it plays a sound and RNG's a flavor text
 			pixel_x += 1
 			buckled_mob.pixel_x += 1
@@ -667,8 +677,8 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 				buckled_mob.visible_message(pick(flavor_text))
 			playsound(buckled_mob.loc, 'sound/effects/noose_idle.ogg', 50, 1, -3)
 		if(4)
-			pixel_x -= 1
-			buckled_mob.pixel_x -= 1
+			pixel_x = initial(pixel_x)
+			buckled_mob.pixel_x = initial(buckled_mob.pixel_x)
 			ticks = 0
 	buckled_mob.adjustOxyLoss(5)
 	buckled_mob.emote("gasp")

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -458,6 +458,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 	new/datum/stack_recipe("cable restraints", /obj/item/weapon/restraints/handcuffs/cable, 15), \
+	new/datum/stack_recipe("noose", /obj/structure/noose, 30, time = 10, one_per_turf = 1, on_floor = 1), \
 	)
 
 /obj/item/stack/cable_coil
@@ -501,30 +502,19 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 	update_icon()
 
 //SUICIDE GOODNESS
-/obj/item/stack/cable_coil/verb/make_noose(mob/user) //So traitors can hang people and stuff
-	set name = "Make Noose"
-	set category = "Object"
-	if((locate(/obj/structure/stool) in user.loc) || (locate(/obj/structure/table) in user.loc) || (locate(/obj/structure/toilet) in user.loc))
-		if(amount < 30)
-			user << "<span class='danger'>You need at least 30 lengths to make a noose!</span>"
-			return
-		user << "<span class='notice'>You begin making a noose with [src]...</span>"
-		if(do_after(user, 100, target = user.loc))
-			if(amount < 30)
-				user << "<span class='danger'>You need at least 30 lengths to make a noose!</span>"
-				return
-			use(30)
-			new /obj/structure/noose(get_turf(user.loc))
-			user.visible_message("<span class='warning'>[user] makes a noose with [src]!</span>",\
-								"<span class='notice'>You make a noose with [src].</span>")
-	else
-		user << "<span class='danger'>You have to be standing on top of a chair/table/toilet to make a noose!</span>"
+
+/obj/item/stack/cable_coil/building_checks(datum/stack_recipe/R, multiplier)
+	if(R.title == "noose")
+		if(!(locate(/obj/structure/stool) in user.loc) && !(locate(/obj/structure/table) in user.loc) && !(locate(/obj/structure/toilet) in user.loc))
+			user << "<span class='warning'>You have to be standing on top of a chair/table/toilet to make a noose!</span>"
+			return 0
+	return ..()
 
 /obj/item/stack/cable_coil/suicide_act(mob/living/user)
 	if((locate(/obj/structure/stool) in user.loc) || (locate(/obj/structure/table) in user.loc) || (locate(/obj/structure/toilet) in user.loc))
 		user.visible_message("<span class='suicide'>[user] is making a noose with the [src]! It looks like \he's trying to commit suicide.</span>")
 		if(do_after(user, 20, target = user.loc))
-			use(1)
+			qdel(src)
 			var/obj/structure/noose/N = new(get_turf(user.loc))
 			N.buckle_mob(user)
 			var/obj/item/organ/limb/affecting = null
@@ -564,6 +554,8 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 			buckled_mob.visible_message("<span class='danger'>[buckled_mob] falls over and hits the ground!</span>",\
 										"<span class='userdanger'>You fall over and hit the ground!</span>")
 			buckled_mob.adjustBruteLoss(10)
+		var/obj/item/stack/cable_coil/C = new(get_turf(src))
+		C.amount = 25
 		qdel(src)
 		return
 	..()
@@ -594,10 +586,10 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 		var/mob/living/M = buckled_mob
 
 		if(M != user)
-			M.visible_message("<span class='notice'>[user] begins to untie the noose over [M]'s neck...</span>",\
+			user.visible_message("<span class='notice'>[user] begins to untie the noose over [M]'s neck...</span>",\
 								"<span class='notice'>You begin to untie the noose over [M]'s neck...</span>")
 			if(do_mob(user, M, 100))
-				M.visible_message("<span class='notice'>[user] unties the noose over [M]'s neck!</span>",\
+				user.visible_message("<span class='notice'>[user] unties the noose over [M]'s neck!</span>",\
 									"<span class='notice'>You untie the noose over [M]'s neck!</span>")
 			else
 				return
@@ -619,7 +611,7 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 		add_fingerprint(user)
 
 /obj/structure/noose/user_buckle_mob(mob/living/M, mob/user)
-	if(!in_range(user, src) || user.stat || user.restrained())
+	if(!in_range(user, src) || user.stat || user.restrained() || !iscarbon(M))
 		return 0
 
 	add_fingerprint(user)

--- a/html/changelogs/Crystalwarrior160 - nooz.yml
+++ b/html/changelogs/Crystalwarrior160 - nooz.yml
@@ -1,0 +1,7 @@
+author: Crystalwarrior160
+delete-after: True
+changes: 
+  - tweak: "Rightclick verb for creating noose was replaced with a crafting menu option when you activate the cables in-hand."
+  - bugfix: "Fixes nooses choking borgs, etc. Now nooses only work on carbons."
+  - bugfix: "Fixed flavortext for nooses misreferencing the victim and not the user when it's supposed to be vice-versa."
+  - bugfix: "Nooses now give cables when cut with wirecutters."


### PR DESCRIPTION
fixes https://github.com/HippieStationCode/HippieStation13/issues/1351
:cl:
- tweak: "Rightclick verb for creating noose was replaced with a crafting menu option when you activate the cables in-hand."
- bugfix: "Fixes nooses choking borgs, etc. Now nooses only work on carbons."
- bugfix: "Fixed flavortext for nooses misreferencing the victim and not the user when it's supposed to be vice-versa."
- bugfix: "Nooses now give cables when cut with wirecutters."
  / :cl:

noosing people is now logged, too
