### PR TITLE
Keycard Buff

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -376,7 +376,7 @@
 	unacidable = 1
 	var/onboard_hud_enabled = 0 //stops conflicts with another diag HUD
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
-	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 100, bio = 100, rad = 60)
+	armor = list(melee = 15, bullet = 5, laser = 10, energy = 5, bomb = 100, bio = 100, rad = 70)
 	scan_reagents = 1
 	var/obj/machinery/doppler_array/integrated/bomb_radar
 
@@ -410,7 +410,7 @@
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT //Same as an emergency firesuit. Not ideal for extended exposure.
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals, /obj/item/weapon/gun/energy/wormhole_projector,
 	/obj/item/weapon/hand_tele, /obj/item/device/aicard)
-	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 100, bio = 100, rad = 60)
+	armor = list(melee = 20, bullet = 5, laser = 10, energy = 5, bomb = 100, bio = 100, rad = 70)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/rd
 
 

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -7,7 +7,7 @@
 	var/event = ""
 	var/screen = 1
 	var/confirmed = 0 //This variable is set by the device that confirms the request.
-	var/confirm_delay = 20 //(2 seconds)
+	var/confirm_delay = 40 //(4 seconds)
 	var/busy = 0 //Busy when waiting for authentication or an event request has been sent from this device.
 	var/obj/machinery/keycard_auth/event_source
 	var/mob/event_triggered_by


### PR DESCRIPTION
Lengthens the time you have to swipe your card for red alert to 4 seconds
