### PR TITLE
Lets drones pick things up through the right click menu.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -387,7 +387,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	if(usr.stat || usr.restrained() || !Adjacent(usr) || usr.stunned || usr.weakened || usr.lying)
 		return
 
-	if(ishuman(usr) || ismonkey(usr))
+	if(ishuman(usr) || ismonkey(usr) || isdrone(usr))
 		if(usr.get_active_hand() == null)
 			usr.UnarmedAttack(src) // Let me know if this has any problems -Giacom | Actually let me know now.  -Sayu
 		/*

--- a/html/changelogs/Dragonrobot - DroneRightClickFix.yml
+++ b/html/changelogs/Dragonrobot - DroneRightClickFix.yml
@@ -1,0 +1,9 @@
+# Your name.  
+author: Killerz104
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.
+changes: 
+  - tweak: "Drones can now pick things up through the right-click menu."


### PR DESCRIPTION
Fixes #1462 

Drones not being able to pick stuff up through the right-click menu is wonky. Alt-click works fine but some people use the right-click menu I guess.

Mainly doing this to see if I did the whole git thing right. Maybe I fucked up setting up git, dunno! Tested on a private server and it works fine.
