### PR TITLE
Watchlist to IRC/Slack update

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -71,6 +71,8 @@
 	var/use_age_restriction_for_jobs = 0 //Do jobs use account age restrictions? --requires database
 	var/see_own_notes = 0 //Can players see their own admin notes (read-only)? Config option in config.txt
 
+	var/announce_watchlist = 0
+
 	//Population cap vars
 	var/soft_popcap				= 0
 	var/hard_popcap				= 0
@@ -259,6 +261,8 @@
 					config.allow_admin_ooccolor = 1
 				if("allow_vote_restart")
 					config.allow_vote_restart = 1
+				if("announce_watchlist")
+					announce_watchlist = 1
 				if("allow_vote_mode")
 					config.allow_vote_mode = 1
 				if("no_dead_vote")

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -282,7 +282,10 @@ var/next_external_rsc = 0
 	var/watchreason = check_watchlist(sql_ckey)
 	if(watchreason)
 		message_admins("<font color='red'><B>Notice: </B></font><font color='blue'>[key_name_admin(src)] is on the watchlist and has just connected - Reason: [watchreason]</font>")
-		send2irc_adminless_only("Watchlist", "[key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")
+		if(config.announce_watchlist)
+			send2irc("Watchlist", "[key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")
+		else
+			send2irc_adminless_only("Watchlist", "[key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")
 
 	var/admin_rank = "Player"
 	if (src.holder && src.holder.rank)

--- a/config/initial_config/config.txt
+++ b/config/initial_config/config.txt
@@ -212,3 +212,6 @@ ANNOUNCE_ADMIN_LOGOUT
 
 ##Uncomment to have an admin message sent anytime an admin connects to a round in play, you can edit the messages in admin.dm
 #ANNOUNCE_ADMIN_LOGIN
+
+##Uncomment to always send a notification to IRC whenever someone on the watchlist connects. When commented, only sends a message if all admins are AFK or no admins are present
+#ANNOUNCE_WATCHLIST


### PR DESCRIPTION
Adds announce_watchlist option to initial config and allows always sending watch list notifications to IRC.
