### PR TITLE
Barricade attack delay, crate health nerf

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -92,14 +92,9 @@ obj/structure/barricade/wooden/proc/take_damage(damage, leave_debris=1, message)
 				W:use(1)
 				visible_message("[user] repairs \the [src]!", "<span class='notice'>You repair \the [src].</span>")
 	else
-		..()
-		var/damage = 0
-		switch(W.damtype)
-			if("fire")
-				damage = W.force * 1
-			if("brute")
-				damage = W.force * 0.75
-		take_damage(damage)
+		user.changeNext_move(CLICK_CD_MELEE)
+		visible_message("<span class='warning'>[user] hits [src] with [W]!</span>", "<span class='warning'>You hit [src] with [W]!</span>")
+		take_damage(W.force)
 
 /obj/structure/barricade/wooden/ex_act(severity, target)
 	switch(severity)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -182,14 +182,9 @@ obj/structure/barricade/wooden/proc/take_damage(damage, leave_debris=1, message)
 			return
 		return
 	else
-		..()
-		var/damage = 0
-		switch(W.damtype)
-			if("fire")
-				damage = W.force * 0.75
-			if("brute")
-				damage = W.force * 0.5
-		take_damage(damage)
+		user.changeNext_move(CLICK_CD_MELEE)
+		visible_message("<span class='warning'>[user] hits [src] with [W]!</span>", "<span class='warning'>You hit [src] with [W]!</span>")
+		take_damage(W.force)
 
 /obj/machinery/deployable/emag_act(mob/user)
 	if (src.emagged == 0)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -124,7 +124,7 @@
 	var/sparks = "securecratesparks"
 	var/emag = "securecrateemag"
 	locked = 1
-	health = 1000
+	health = 200
 
 /obj/structure/closet/crate/secure/weapon
 	desc = "A secure weapons crate."

--- a/html/changelogs/Dan Hibiki - Craticades.yml
+++ b/html/changelogs/Dan Hibiki - Craticades.yml
@@ -1,0 +1,5 @@
+author: Dan Hibiki
+delete-after: True
+changes: 
+  - tweak: "Lowered the amount of health secure crates had to rebase amount"
+  - tweak: "Added cooldown to attacking wooden barricades to prevent spam"


### PR DESCRIPTION
Attacking wooden barricades has no delay currently, this uses the predfined click delay. Lowered the crate health from a staggering 1000 to 200 before rebase.
