### PR TITLE
Adminhelp and notice to IRC/Slack rework

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -72,6 +72,7 @@
 	var/see_own_notes = 0 //Can players see their own admin notes (read-only)? Config option in config.txt
 
 	var/announce_watchlist = 0
+	var/announce_adminhelps = 0
 
 	//Population cap vars
 	var/soft_popcap				= 0
@@ -261,8 +262,8 @@
 					config.allow_admin_ooccolor = 1
 				if("allow_vote_restart")
 					config.allow_vote_restart = 1
-				if("announce_watchlist")
-					announce_watchlist = 1
+				if("announce_adminhelps")
+					config.announce_adminhelps = 1
 				if("allow_vote_mode")
 					config.allow_vote_mode = 1
 				if("no_dead_vote")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -108,12 +108,12 @@
 	src << "<span class='adminnotice'>PM to-<b>Admins</b>: [original_msg]</span>"
 
 	//send it to irc if nobody is on and tell us how many were on
-	var/admin_number_present = send2irc_adminless_only(ckey,original_msg)
+	var/admin_number_present = send2irc_admin_notice_handler("adminhelp", ckey, original_msg)
 	log_admin("ADMINHELP: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins who have +BAN.")
 	feedback_add_details("admin_verb","AH") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 
-/proc/send2irc_adminless_only(source, msg, requiredflags = R_BAN)
+/proc/calculate_admins(type, requiredflags = R_BAN)
 	var/admin_number_total = 0		//Total number of admins
 	var/admin_number_afk = 0		//Holds the number of admins who are afk
 	var/admin_number_ignored = 0	//Holds the number of admins without +BAN (so admins who are not really admins)
@@ -132,12 +132,61 @@
 			invalid = 1
 		if(invalid)
 			admin_number_decrease++
-	var/admin_number_present = admin_number_total - admin_number_decrease	//Number of admins who are neither afk nor invalid
-	if(admin_number_present <= 0)
-		if(!admin_number_afk && !admin_number_ignored)
-			send2irc(source, "[msg] - No admins online")
-		else
-			send2irc(source, "[msg] - All admins AFK ([admin_number_afk]/[admin_number_total]) or skipped ([admin_number_ignored]/[admin_number_total])")
+	switch(type)
+		if("ignored")
+			return admin_number_ignored
+		if("total")
+			return admin_number_total
+		if("away")
+			return admin_number_afk
+		if("present")
+			return admin_number_total - admin_number_decrease
+	return 0
+
+
+/proc/send2irc_admin_notice_handler(type, source, msg)
+	var/afk_admins = calculate_admins("away")
+	var/total_admins = calculate_admins("total")
+	var/ignored_admins = calculate_admins("ignored")
+	var/admin_number_present = calculate_admins("present")	//Number of admins who are neither afk nor invalid
+	var/irc_message_afk = "[msg] - All admins AFK ([afk_admins]/[total_admins]) or skipped ([ignored_admins]/[total_admins])"
+	var/irc_message_normal = "[msg] - heard by [admin_number_present] non-AFK admins who have +BAN."
+	var/irc_message_adminless = "[msg] - No admins online"
+
+	switch(type)
+		if("adminhelp")
+			if(config.announce_adminhelps)
+				send2irc(source, irc_message_normal)
+			else
+				if(admin_number_present <= 0)
+					if(!afk_admins && !ignored_admins)
+						send2irc(source, irc_message_adminless)
+					else if(afk_admins >= 1)
+						send2irc(source, irc_message_afk)
+					else
+						send2irc(source, irc_message_normal)
+		if("watchlist")
+			if(config.announce_watchlist)
+				send2irc(source, irc_message_normal)
+			else
+				if(admin_number_present <= 0)
+					if(!afk_admins && !ignored_admins)
+						send2irc(source, irc_message_adminless)
+					else if(afk_admins >= 1)
+						send2irc(source, irc_message_afk)
+					else
+						send2irc(source, irc_message_normal)
+		if("new_player")
+			if(config.irc_first_connection_alert)
+				send2irc(source, irc_message_normal)
+			else
+				if(admin_number_present <= 0)
+					if(!afk_admins && !ignored_admins)
+						send2irc(source, irc_message_adminless)
+					else if(afk_admins >= 1)
+						send2irc(source, irc_message_afk)
+					else
+						send2irc(source, irc_message_normal)
 	return admin_number_present
 
 /proc/send2irc(msg,msg2)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -174,8 +174,7 @@ var/next_external_rsc = 0
 
 		if (config.notify_new_player_age >= 0)
 			message_admins("New user: [key_name_admin(src)] is connecting here for the first time.")
-			if (config.irc_first_connection_alert)
-				send2irc_adminless_only("New-user", "[key_name(src)] is connecting for the first time!")
+			send2irc_admin_notice_handler("new_player","New-user", "[key_name(src)] is connecting for the first time!")
 
 		player_age = 0 // set it from -1 to 0 so the job selection code doesn't have a panic attack
 
@@ -282,10 +281,7 @@ var/next_external_rsc = 0
 	var/watchreason = check_watchlist(sql_ckey)
 	if(watchreason)
 		message_admins("<font color='red'><B>Notice: </B></font><font color='blue'>[key_name_admin(src)] is on the watchlist and has just connected - Reason: [watchreason]</font>")
-		if(config.announce_watchlist)
-			send2irc("Watchlist", "[key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")
-		else
-			send2irc_adminless_only("Watchlist", "[key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")
+		send2irc_admin_notice_handler("watchlist", "Watchlist", "[key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")
 
 	var/admin_rank = "Player"
 	if (src.holder && src.holder.rank)

--- a/config/initial_config/config.txt
+++ b/config/initial_config/config.txt
@@ -215,3 +215,7 @@ ANNOUNCE_ADMIN_LOGOUT
 
 ##Uncomment to always send a notification to IRC whenever someone on the watchlist connects. When commented, only sends a message if all admins are AFK or no admins are present
 #ANNOUNCE_WATCHLIST
+
+##Uncomment to always send a notification to IRC whenever someone adminhelps. When commented, only sends a message if all admins are AFK or no admins are present
+ANNOUNCE_ADMINHELPS
+


### PR DESCRIPTION
Centralizes adminhelp and admin notice to IRC/Slack handling. 
Separates the process for calculating the admins away, online, and without ban powers.

Rather than separate checks before each attempt to send to IRC/Slack in individual files, all handling is done by send2irc_admin_notice_handler(). On modification, requires an extra switch case added with the type of message being handled and the methodology of handling.

Allows sending adminhelps to IRC/Slack regardless of away status of online admins and adds the option to the initial config.
