### PR TITLE
Hub mentor retrieval

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -103,7 +103,11 @@ var/global/list/map_transition_config = MAP_TRANSITION_CONFIG
 		s["host"] = host ? host : null
 
 		var/admins = 0
+		var/mentors = 0
 		for(var/client/C in clients)
+			var/mentor = mentor_datums[C.ckey]
+			if(mentor)
+				mentors++
 			if(C.holder)
 				if(C.holder.fakekey)
 					continue	//so stealthmins aren't revealed by the hub
@@ -114,6 +118,7 @@ var/global/list/map_transition_config = MAP_TRANSITION_CONFIG
 		s["revision"] = revdata.revision
 		s["revision_date"] = revdata.date
 		s["admins"] = admins
+		s["mentors"] = mentors
 		s["gamestate"] = 1
 		if(ticker)
 			s["gamestate"] = ticker.current_state


### PR DESCRIPTION
Allows the hub and the slack/IRC bot to easily retrieve the amount of online mentors.
