### PR TITLE
Fixes bug where pAIs could not use messenger or chatroom.

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -263,6 +263,9 @@ Class Procs:
 		return
 	return 1
 
+/mob/living/silicon/pai/canUseTopic(atom/movable/M)
+	return 1
+
 /mob/living/silicon/robot/canUseTopic(atom/movable/M, be_close = 0)
 	if(stat || lockcharge || stunned || weakened)
 		return

--- a/html/changelogs/Dragonrobot - PAIMessengerFix.yml
+++ b/html/changelogs/Dragonrobot - PAIMessengerFix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Killerz104
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes bug where pAIs could not use the messenger or chatroom in their software."


### PR DESCRIPTION
This should fix the issue where pAIs cannot use the Digital Messenger or Chatroom Client because they don't have the dexterity. Tested and it seems to work fine.

I was worried this fix would let pAIs control stuff they shouldn't be able to, but they still seem to be limited in the same ways they were before.
