### PR TITLE
Defines a name for proc queue

### DIFF
--- a/code/controllers/subsystem/procqueue.dm
+++ b/code/controllers/subsystem/procqueue.dm
@@ -1,4 +1,5 @@
 var/datum/subsystem/procqueue/procqueue
+	name = "Proc Queue"
 
 /datum/subsystem/procqueue
 	var/list/queue = list()


### PR DESCRIPTION
Gives it a name so its not a nameless stat object in the MC tab, minor change
