### PR TITLE
Defines a name for proc queue

### DIFF
--- a/code/controllers/subsystem/procqueue.dm
+++ b/code/controllers/subsystem/procqueue.dm
@@ -1,4 +1,5 @@
 var/datum/subsystem/procqueue/procqueue
+	name = "Proc Queue"
 
 /datum/subsystem/procqueue
 	var/list/queue = list()

--- a/code/controllers/subsystem/procqueue.dm
+++ b/code/controllers/subsystem/procqueue.dm
@@ -1,7 +1,7 @@
 var/datum/subsystem/procqueue/procqueue
-	name = "Proc Queue"
 
 /datum/subsystem/procqueue
+	name = "Proc Queue"
 	var/list/queue = list()
 
 /datum/subsystem/procqueue/New()


### PR DESCRIPTION
Doesn't have one now so it shows up as a nameless statclick, this is just so things look pretty. Last PR wasn't right
