### PR TITLE
Revert "Fixes bug where AIs can't track people when an NTSL script changes $source"

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -7,7 +7,7 @@
 /mob/living/silicon/ai/compose_track_href(atom/movable/speaker, namepart)
 	var/mob/M = speaker.GetSource()
 	if(M)
-		return "<a href='?src=\ref[src];track=[M.GetVoice()]'>"
+		return "<a href='?src=\ref[src];track=[html_encode(namepart)]'>"
 	return ""
 
 /mob/living/silicon/ai/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)

--- a/html/changelogs/Dragonrobot - NTSLTrackingFix.yml
+++ b/html/changelogs/Dragonrobot - NTSLTrackingFix.yml
@@ -1,6 +1,0 @@
-author: Killerz104
-
-delete-after: True
-
-changes: 
-  - bugfix: "Fixes bug where changing $source with NTSL scripts prevents the AI from tracking people."


### PR DESCRIPTION
Reverts HippieStationCode/HippieStation13#1661

Was told that it did break some shit, more damage to voice changers.
