### PR TITLE
issue #1859 Weapons now show correct sprite/overlays respective to how much ammo they have left.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.txt
 *.int
 *.db
+code/game/gamemodes/abduction/abduction_gear.dm

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@
 *.txt
 *.int
 *.db
-code/game/gamemodes/abduction/abduction_gear.dm

--- a/code/modules/awaymissions/mission_code/stationCollision.dm
+++ b/code/modules/awaymissions/mission_code/stationCollision.dm
@@ -66,6 +66,7 @@ obj/item/weapon/gun/energy/laser/retro/sc_retro
 	desc = "An older model of the basic lasergun, no longer used by Nanotrasen's security or military forces."
 //	projectile_type = "/obj/item/projectile/practice"
 	clumsy_check = 0 //No sense in having a harmless gun blow up in the clowns face
+	overlay_ammo = 4 //number of sprite cartridges visible. Used in energy.dm to switch sprites
 
 //Syndicate sub-machine guns.
 /obj/item/weapon/gun/projectile/automatic/c20r/sc_c20r
@@ -90,6 +91,7 @@ obj/item/weapon/gun/energy/laser/retro/sc_retro
 	name = "Old laser"
 	desc = "A once potent weapon, years of dust have collected in the chamber and lens of this weapon, weakening the beam significantly."
 	clumsy_check = 0
+	overlay_ammo = 4 //number of sprite cartridges visible. Used in energy.dm to switch sprites
 
 /*
  * Safe code hints

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -76,14 +76,12 @@
 
 /obj/item/weapon/gun/energy/update_icon(mob/user = usr)
 	overlays.Cut()
-	var/charge = -1 // charge for weapons that don't use shaded_charge
+	var/charge = -1 // charge for weapons that use shaded_charge
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	var/ammo_left = round(power_supply.charge / shot.e_cost)
 	var/max_ammo = power_supply.maxcharge / shot.e_cost
 	var/overlay_ammo_increments = max_ammo / src.overlay_ammo //so we know when to change the overlay sprites on the weapon
 	var/overlay_counter = round(ammo_left / overlay_ammo_increments) //number of overlay sprites for the current ammo in the weapon
-	user << "<span class='notice'>power supply charge is now [power_supply.charge].</span>"
-	user << "<span class='notice'>ammo_left is now set to [ammo_left].</span>"
 	var/itemState = null
 	var/iconState = "[icon_state]_charge"
 	if(!initial(item_state))
@@ -97,9 +95,7 @@
 		overlays += "[icon_state]_empty"
 	else
 		if(!shaded_charge && ammo_left > 1)
-			user << "<span class='notice'>overlay_counter = [overlay_counter].</span>"
 			for(var/i = overlay_counter;i > 0;i--)
-				user << "<span class='notice'>looped [i] times.</span>"
 				overlays += image(icon = icon, icon_state = iconState, pixel_x = ammo_x_offset * (i -1))
 		else 
 			charge = Ceiling((power_supply.charge / power_supply.maxcharge) * 4)
@@ -112,7 +108,7 @@
 	if(knife)
 		var/iconK = "knife"
 		overlays += image(icon = 'icons/obj/guns/attachments.dmi', icon_state = iconK, pixel_x = knife_x_offset, pixel_y = knife_y_offset)
-	if(itemState) //I'm not sure where the sprite's are for the itemState, it appears there is a sprite missing for when there is only 1 bullet in the weapon chambered. Code below is a work around in that the itemState wont change to show just 1 bullet.
+	if(itemState) //I'm not sure where the sprite's are for the itemState, it appears that there is a sprite missing for when there is only 1 bullet in the weapon chambered. Code below is a work around in that the itemState wont change to show just 1 bullet.
 		if(charge != -1)//lasers are separate
 			itemState += "[charge]"
 			item_state = itemState

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -74,7 +74,7 @@
 	update_icon()
 	return
 
-/obj/item/weapon/gun/energy/update_icon(mob/user = usr)
+/obj/item/weapon/gun/energy/update_icon()
 	overlays.Cut()
 	var/charge = -1 // charge for weapons that use shaded_charge
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -25,6 +25,7 @@
 	force = 10
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 4
+	overlay_ammo = 4 //number of sprite cartridges visible. Used in energy.dm to switch sprites
 
 /obj/item/weapon/gun/energy/gun/dragnet
 	name = "\improper DRAGnet"
@@ -47,6 +48,7 @@
 	can_flashlight = 0
 	trigger_guard = 0
 	ammo_x_offset = 2
+	overlay_ammo = 4 //number of sprite cartridges visible. Used in energy.dm to switch sprites
 
 /obj/item/weapon/gun/energy/gun/nuclear
 	name = "advanced energy gun"

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -9,6 +9,7 @@
 	slot_flags = SLOT_BACK
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pulse, /obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser)
 	cell_type = "/obj/item/weapon/stock_parts/cell/pulse"
+	overlay_ammo = 4 //number of sprite cartridges visible. Used in energy.dm to switch sprites
 
 /obj/item/weapon/gun/energy/pulse/attack_self(mob/living/user)
 	select_fire(user)
@@ -32,6 +33,7 @@
 	can_knife = 1
 	knife_x_offset = 18
 	knife_y_offset = 12
+	overlay_ammo = 4
 
 /obj/item/weapon/gun/energy/pulse/carbine/loyalpin
 
@@ -44,6 +46,7 @@
 	item_state = "gun"
 	cell_type = "/obj/item/weapon/stock_parts/cell/pulse/pistol"
 	can_charge = 0
+	overlay_ammo = 4
 
 /obj/item/weapon/gun/energy/pulse/pistol/loyalpin
 
@@ -53,6 +56,7 @@
 	desc = "A heavy-duty energy rifle built for pure destruction."
 	cell_type = "/obj/item/weapon/stock_parts/cell/infinite"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pulse)
+	overlay_ammo = 4
 
 /obj/item/weapon/gun/energy/pulse/destroyer/attack_self(mob/living/user)
 	user << "<span class='danger'>[src.name] has three settings, and they are all DESTROY.</span>"
@@ -63,3 +67,4 @@
 	icon_state = "m1911"
 	item_state = "gun"
 	cell_type = "/obj/item/weapon/stock_parts/cell/infinite"
+	overlay_ammo = 4

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -331,7 +331,7 @@
 	origin_tech = "combat=3;materials=4;powerstorage=3;magnets=2"
 	ammo_type = list(/obj/item/ammo_casing/energy/temp, /obj/item/ammo_casing/energy/temp/hot)
 	cell_type = "/obj/item/weapon/stock_parts/cell/high"
-	overlay_ammo = 5 //number of sprite cartridges visible. Used in energy.dm to switch sprites
+	overlay_ammo = 4 //number of sprite cartridges visible. Used in energy.dm to switch sprites
 
 /obj/item/weapon/gun/energy/temperature/attack_self(mob/living/user)
 	select_fire(user)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -15,6 +15,7 @@
 	can_knife = 1
 	knife_x_offset = 17
 	knife_y_offset = 9
+	overlay_ammo = 4 //number of sprite cartridges visible. Used in energy.dm to switch sprites
 
 /obj/item/weapon/gun/energy/ionrifle/emp_act(severity)
 	return
@@ -29,6 +30,7 @@
 	ammo_x_offset = 2
 	flight_x_offset = 18
 	flight_y_offset = 11
+	overlay_ammo = 4 //number of sprite cartridges visible. Used in energy.dm to switch sprites
 
 /obj/item/weapon/gun/energy/decloner
 	name = "biological demolecularisor"
@@ -128,6 +130,7 @@
 	icon_state = "xray"
 	ammo_type = list(/obj/item/ammo_casing/energy/mindflayer)
 	ammo_x_offset = 2
+	overlay_ammo = 4 //number of sprite cartridges visible. Used in energy.dm to switch sprites
 
 /obj/item/weapon/gun/energy/kinetic_accelerator
 	name = "proto-kinetic accelerator"
@@ -328,6 +331,7 @@
 	origin_tech = "combat=3;materials=4;powerstorage=3;magnets=2"
 	ammo_type = list(/obj/item/ammo_casing/energy/temp, /obj/item/ammo_casing/energy/temp/hot)
 	cell_type = "/obj/item/weapon/stock_parts/cell/high"
+	overlay_ammo = 5 //number of sprite cartridges visible. Used in energy.dm to switch sprites
 
 /obj/item/weapon/gun/energy/temperature/attack_self(mob/living/user)
 	select_fire(user)

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -5,6 +5,7 @@
 	item_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
 	ammo_x_offset = 3
+	overlay_ammo = 4 //number of sprite cartridges visible. Used in energy.dm to switch sprites
 
 /obj/item/weapon/gun/energy/stunrevolver
 	name = "stun revolver"
@@ -14,6 +15,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/gun)
 	can_flashlight = 0
 	ammo_x_offset = 1
+	overlay_ammo = 1
 
 /obj/item/weapon/gun/energy/gun/advtaser
 	name = "hybrid taser"
@@ -22,6 +24,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/disabler)
 	origin_tech = null
 	ammo_x_offset = 2
+	overlay_ammo = 4
 
 /obj/item/weapon/gun/energy/gun/advtaser/cyborg
 	name = "cyborg taser"
@@ -63,6 +66,7 @@
 	item_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 3
+	overlay_ammo = 4
 
 /obj/item/weapon/gun/energy/disabler/cyborg
 	name = "cyborg disabler"


### PR DESCRIPTION
I've changed the way the old system works a little because it's the only way I could think to fix this issue. I'm not experienced with SS13 and would feel better if somebody else took some time to look at the issue first before committing my fix. Maybe there is an easier way to fix the problem but here is my solution. 

If I’m right I think the problem was inside energy.dm in the update_icon function the main line causing a problem is 
`var/ratio = Ceiling((power_supply.charge / power_supply.maxcharge) * 4)`
If you charge your taser to 300 it will show you having 2 shots left even though you only should have 1 shot because for stun ammo it's 200 per shot. That line of code reads... 
`var/ratio = Ceiling((300 / 1000) * 4)`
The answer is 2 after you round up 1.2.

This ratio variable is used to determine how many shots to add to the overlays and sprites on a weapon which is why it shows you having 2 shots instead of 1 left. So when you fire your last shot its not showing the correct sprite for an empty weapon because, now your charge will be 100 making the ratio variable equate to 1 (rounding up the number 0.4).

So the current system is always at risk of rounding up the number to give a false sprite. My way of doing it doesn't work out a ratio and then round the number to determine how many overlays to add. It instead takes the number of shots left in the cell and then adds the correct number of overlays based on the weapon being used. 

This means that I've had to add the variable overlay_ammo to energy guns. This variable is the number of ammo a weapon can hold on its sprite. So for example tasers have 4 while the stun revolver only has 1 visible overlay for ammo.
