### PR TITLE
Makes gang tags lower layer if on a floor.

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -36,6 +36,9 @@
 	var/datum/gang/gang
 
 /obj/effect/decal/cleanable/crayon/gang/New(location, var/datum/gang/G, var/e_name = "gang tag", var/rotation = 0)
+	var/target = get_turf(src)
+	if(istype(target, /turf/simulated/floor))
+		layer = 2.9
 	if(!type || !G)
 		qdel(src)
 


### PR DESCRIPTION
![gangtool](https://cloud.githubusercontent.com/assets/7472150/13377964/bc0a3e7a-ddc0-11e5-95f6-f37d75db90f6.png)
Attemps to fix #1886

Obviously this gives a big advantage to gang members. An open lockers almost covers the entire thing, but at least it's not ugly as fuck.

headmins shall decide.
