### PR TITLE
Pool performance update + bloodpool feature.

### DIFF
--- a/code/game/machinery/pooldrain.dm
+++ b/code/game/machinery/pooldrain.dm
@@ -8,9 +8,14 @@
 	var/status = 0 //1 is drained, 0 is full.
 	var/timer = 0
 	var/cooldown
+	var/obj/machinery/poolcontroller/poolcontrol = null
+
+/obj/machinery/drain/initialize()
+	for(var/obj/machinery/poolcontroller/control in range(5,src))
+		src.poolcontrol += control
 
 /obj/machinery/drain/process()
-	if(status == 0) //don't drain an empty pool.
+	if(!status) //don't drain an empty pool.
 		for(var/obj/item/absorbo in orange(1,src))
 			if(absorbo.w_class == 1)
 				step_towards(absorbo, src)
@@ -39,8 +44,12 @@
 					undrained2.icon_state = "overlay"
 				for(var/obj/effect/effect/waterspout/undrained3 in range(1,src))
 					qdel(undrained3)
-				for(var/obj/machinery/poolcontroller/undrained4 in range(5,src))
-					undrained4.drained = 0
+				poolcontrol.drained = 0
+				if(poolcontrol.bloody < 1000)
+					poolcontrol.bloody /= 2
+				if(poolcontrol.bloody > 1000)
+					poolcontrol.bloody /= 4
+				poolcontrol.changecolor()
 				status = 0
 				active = 0
 			return
@@ -54,9 +63,9 @@
 						step_towards(whirlo,src)
 				for(var/mob/living/carbon/human/whirlm in orange(2,src))
 					step_towards(whirlm,src)
-					if(prob(10))
-						whirlm.Weaken(1)
-					for(var/i in list(1,2,4,8,4,2,1)) //swril!
+					if(prob(20))
+						whirlm.Weaken(2)
+					for(var/i in list(1,2,4,8,4,2,1)) //swirl!
 						whirlm.dir = i
 						sleep(1)
 					if(whirlm.loc == src.loc)
@@ -138,8 +147,7 @@
 
 
 
-/obj/machinery/poolfilter/attackby(obj/item/weapon/W, mob/user)
-	if(istype(W, /obj/item/weapon/crowbar) && anchored)
-		user << "You search the filter."
-		for(var/obj/O in contents)
-			O.loc = src.loc
+/obj/machinery/poolfilter/attack_hand(mob/user)
+	user << "You search the filter."
+	for(var/obj/O in contents)
+		O.loc = src.loc

--- a/code/game/objects/structures/pool.dm
+++ b/code/game/objects/structures/pool.dm
@@ -20,9 +20,6 @@
 
 //Put people out of the water
 /turf/simulated/floor/MouseDrop_T(mob/M as mob, mob/user as mob)
-	var/turf/loc = get_turf(usr)
-	if(loc.name == "Drained Pool")
-		return
 	if(isobserver(usr))
 		return
 	if(user.stat || user.lying || !Adjacent(user) || !M.Adjacent(user)|| !iscarbon(M))
@@ -34,7 +31,6 @@
 				T.Exited(M)
 				M.forceMove(src)
 				user << "<span class='notice'>You get out of the pool.</span>"
-				playsound(src, 'sound/effects/water_exit.ogg', 20, 1)
 		return ..()
 	if(!M.swimming) //can't put yourself up if you are not swimming
 		return ..()
@@ -47,7 +43,6 @@
 			T.Exited(M)
 			M.forceMove(src)
 			user << "<span class='notice'>You get out of the pool.</span>"
-			playsound(src, 'sound/effects/water_exit.ogg', 20, 1)
 	else
 		user.visible_message("<span class='notice'>[M] is being pulled to the poolborder by [user].</span>", \
 						"<span class='notice'>You start getting [M] out of the pool.")
@@ -70,6 +65,15 @@
 		if(istype(get_turf(A), /turf/simulated/pool/water) && !istype(T, /turf/simulated/pool/water)) //!(locate(/obj/structure/pool/ladder) in get_turf(A).loc)
 			return 0
 	return ..()
+
+/turf/simulated/pool/water/Exited(mob/M)
+	..()
+	var/turf/T = get_turf(M)
+	if(istype(M) && istype(watereffect) && istype(T) && src.y != T.y) //We're checking for y variable here so layering isn't fucked when you move horizontally
+		watereffect.layer = M.layer - 0.1 //Always a step behind!
+		spawn(3)
+			watereffect.layer = initial(watereffect.layer)
+
 
 /obj/overlay/water
 	name = "Water"
@@ -94,14 +98,43 @@
 	watereffect = new /obj/overlay/water(src)
 
 
-/turf/simulated/pool/water/ChangeTurf(var/path)
-	. = ..()
-	if(. != src)
-		qdel(watereffect) //Remove the water overlay so it doesn't hang around
+/turf/simulated/pool/water/ex_act(severity, target)
+	..()
+	switch(severity)
+		if(1)
+			src.ReplaceWithLattice()
+		if(2)
+			src.ChangeTurf(/turf/simulated/floor/plating)
+		if(3)
+			return
+
+/turf/simulated/pool/water/Exited(mob/M)
+	..()
+	var/turf/T = get_turf(M)
+	if(istype(M) && istype(watereffect) && istype(T) && src.y != T.y) //We're checking for y variable here so layering isn't fucked when you move horizontally
+		watereffect.layer = M.layer - 0.1 //Always a step behind!
+		spawn(3)
+			watereffect.layer = initial(watereffect.layer)
+
+
+/turf/simulated/pool/water/ChangeTurf(path)
+	if(!path)			return
+	if(path == type)	return src
+
+	SSair.remove_from_active(src)
+	src.watereffect = null
+	var/turf/W = new path(src)
+	if(istype(W, /turf/simulated))
+		W:Assimilate_Air()
+		W.RemoveLattice()
+	W.levelupdate()
+	W.CalculateAdjacentTurfs()
+
+
 
 //put people in water, including you
 /turf/simulated/pool/water/MouseDrop_T(mob/M as mob, mob/user as mob)
-	if(drained || !has_gravity(src))
+	if(!has_gravity(src))
 		return
 	if(user.stat || user.lying || !Adjacent(user) || !M.Adjacent(user)|| !iscarbon(M))
 		return
@@ -132,7 +165,6 @@
 	if(!has_gravity(src)) //Fairly important
 		return
 	else if(drained) //KATHUNKS
-
 		if(ishuman(A))
 			var/mob/living/carbon/human/H = A
 			if(H.swimming == 0)
@@ -193,14 +225,6 @@
 					playsound(src, 'sound/effects/splash.ogg', 60, 1, 1)
 					H.Weaken(3)
 					H.swimming = 1
-
-/turf/simulated/pool/water/Exited(mob/M)
-	..()
-	var/turf/T = get_turf(M)
-	if(istype(M) && istype(watereffect) && istype(T) && src.y != T.y) //We're checking for y variable here so layering isn't fucked when you move horizontally
-		watereffect.layer = M.layer - 0.1 //Always a step behind!
-		spawn(3)
-			watereffect.layer = initial(watereffect.layer)
 
 /obj/structure/pool
 	name = "pool"
@@ -363,11 +387,11 @@
 			playsound(src, 'sound/effects/watersplash.ogg', 8, 1, 1)
 			src.splashed = 1
 			var/obj/effect/splash/S = new /obj/effect/splash(user.loc)
-			animate(S, alpha = 40,  time = 7)
+			animate(S, alpha = 0,  time = 8)
 			S.Move(src)
-			spawn(25)
+			spawn(20)
 				qdel(S)
-				spawn(12)
+				spawn(5)
 					src.splashed = 0 //Otherwise, infinite splash party.
 
 			for(var/mob/living/carbon/human/L in src)


### PR DESCRIPTION
Minor tweak to how the pool works, code wise, I've been told it'd be more efficient to use directly linked var instead of for() when possible.

This makes the pool able to be destroyed properly by explosions/other things that would kill floors.

(EDIT) This will also allow people to get in or out of the pool even when it's drained.

Also, this allows the pool to be filled to the brim with blood. Putting blood into the pool only changes it's color, and if too much is put in, it stops cleaning itself. The only way to reset that is to drain it and fill it again.

![poolblood](https://cloud.githubusercontent.com/assets/7472150/13515526/0bfedd2e-e180-11e5-92bd-234bd2d78f55.png)

(Next PR I make will be bug fixes, I swear.)
