### PR TITLE
Cult Rune Delay

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -71,6 +71,7 @@ Word definitions:
 	return
 
 /obj/effect/rune/attack_hand(mob/living/user)
+	user.changeNext_move(CLICK_CD_MELEE)
 	if(!iscultist(user))
 		user << "<span class='warning'>You aren't able to understand the words of [src].</span>"
 		return

--- a/html/changelogs/MemendiaRune.yml
+++ b/html/changelogs/MemendiaRune.yml
@@ -1,0 +1,6 @@
+author: Memendia
+
+delete-after: True
+
+changes: 
+  - tweak: "Cult runes now have a delay."


### PR DESCRIPTION
Adds a delay to all cult runes to prevent instant death and general spam.
