### PR TITLE
Mindslave Implants *Complete*

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1063,7 +1063,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/implants/mindslave
 	name = "Mindslave Implant"
-	desc = "An implant injected into another body, forcing the vitcim to obey any command by the user for a limited time."
+	desc = "An implant injected into another body, forcing the vitcim to obey any command by the user for around 15 to 20 mintues."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_mindslave
 	cost = 9
 	surplus = 20

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1061,6 +1061,13 @@ var/list/uplink_items = list()
 	cost = 2
 	surplus = 30
 
+/datum/uplink_item/implants/mindslave
+	name = "Mindslave Implant"
+	desc = "An implant injected into another body, forcing the vitcim to obey any command by the user for a limited time."
+	item = /obj/item/weapon/storage/box/syndie_kit/imp_mindslave
+	cost = 9
+	surplus = 20
+
 
 //CYBERNETIC IMPLANTS
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1064,6 +1064,7 @@ var/list/uplink_items = list()
 /datum/uplink_item/implants/mindslave
 	name = "Mindslave Implant"
 	desc = "An implant injected into another body, forcing the vitcim to obey any command by the user for around 15 to 20 mintues."
+	excludefrom = list(/datum/game_mode/nuclear)
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_mindslave
 	cost = 9
 	surplus = 20

--- a/code/game/objects/items/weapons/implants/implant_mindslave.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindslave.dm
@@ -26,7 +26,7 @@
 		target << "<span class='notice'>You feel a surge of loyalty towards [user].</span>"
 		target << "<span class='userdanger'> You MUST obey any command given to you by your master(that doesn't violate any rules). You are an antag while mindslaved.</span>"
 		target << "<span class='danger'>You CANNOT harm your master.</span>"
-		var/time = 9000 + rand(60,300)
+		var/time = 9000 + rand(60,3000)
 		timerid = addtimer(src,"remove_mindslave",time)
 		target.mind.special_role = "Mindslave"
 		slavememory = "<b>Your mindslave master is</b>: [user]. Obey any command they give you!"
@@ -47,7 +47,7 @@
 /obj/item/weapon/implant/mindslave/proc/remove_mindslave()
 	if(imp_in)
 		imp_in.mind.special_role = ""
-		imp_in << "<span class='danger'>You feel your free will come back to you! REMEMBER THAT YOU ARE NOW NO LONGER AN ANTAG, BUT YOU NO LONGER HAVE TO LISTEN TO YOUR MASTER.</span>"
+		imp_in << "<span class='userdanger'>You feel your free will come back to you! REMEMBER THAT YOU ARE NOW NO LONGER AN ANTAG, BUT YOU NO LONGER HAVE TO LISTEN TO YOUR MASTER.</span>"
 		imp_in.memory -= slavememory
 
 /obj/item/weapon/implanter/mindslave

--- a/code/game/objects/items/weapons/implants/implant_mindslave.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindslave.dm
@@ -39,6 +39,7 @@
 		protect_objective.target = user.mind
 		protect_objective.explanation_text = "Protect [user], your mindslave master. Obey any command he gives."
 		target.mind.objectives += protect_objective
+		log_admin("[user]([user.ckey]) made a mindslave out of [target]([target.ckey]).")
 		return 1
 	return 0
 
@@ -59,6 +60,7 @@
 		imp_in << "<span class='userdanger'>You feel your free will come back to you! You no longer have to obey your master!</span>"
 		imp_in << "<span class='userdanger'>If you were not an antagonist BEFORE being mindslave, then you no longer are one.</span>"
 		protect_objective = null
+		log_admin("[imp_in]([imp_in.ckey]) is no longer a mindslave.")
 
 /obj/item/weapon/implanter/mindslave
 	name = "implanter (mind slave)"

--- a/code/game/objects/items/weapons/implants/implant_mindslave.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindslave.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/implant/mindslave
 	name = "mindslave implant"
-	desc = "Now YOU too can have your very own mindslave! Pop this implant into anybody and they'll obey any command you give for a limited time."
+	desc = "Now YOU too can have your very own mindslave! Pop this implant into anybody and they'll obey any command you give for around 15 to 20 minutes."
 	origin_tech = "materials=2;biotech=4;programming=4"
 	activated = 0
 	var/timerid
@@ -24,8 +24,8 @@
 		return 0
 	if(..())
 		target << "<span class='notice'>You feel a surge of loyalty towards [user].</span>"
-		target << "\red You MUST obey any command given to you by your master(that doesn't violate any rules). You are an antag while mindslaved."
-		target << "\red You CANNOT harm your master."
+		target << "<span class='userdanger'> You MUST obey any command given to you by your master(that doesn't violate any rules). You are an antag while mindslaved.</span>"
+		target << "<span class='danger'>You CANNOT harm your master.</span>"
 		var/time = 9000 + rand(60,300)
 		timerid = addtimer(src,"remove_mindslave",time)
 		target.mind.special_role = "Mindslave"
@@ -47,7 +47,7 @@
 /obj/item/weapon/implant/mindslave/proc/remove_mindslave()
 	if(imp_in)
 		imp_in.mind.special_role = ""
-		imp_in << "\red You feel your free will come back to you! REMEMBER THAT YOU ARE NOW NO LONGER AN ANTAG, BUT YOU NO LONGER HAVE TO LISTEN TO YOUR MASTER."
+		imp_in << "<span class='danger'>You feel your free will come back to you! REMEMBER THAT YOU ARE NOW NO LONGER AN ANTAG, BUT YOU NO LONGER HAVE TO LISTEN TO YOUR MASTER.</span>"
 		imp_in.memory -= slavememory
 
 /obj/item/weapon/implanter/mindslave
@@ -57,22 +57,3 @@
 	imp = new /obj/item/weapon/implant/mindslave(src)
 	..()
 	update_icon()
-
-/* Backup code
-/datum/uplink_item/implants/mindslave
-	name = "Mindslave Implant"
-	desc = "An implant injected into another body, forcing the vitcim to obey any command by the user for a limited time."
-	item = /obj/item/weapon/storage/box/syndie_kit/imp_mindslave
-	cost = 9
-	surplus = 20
-
-/obj/item/weapon/storage/box/syndie_kit/imp_mindslave
-	name = "Mindslave Implant (with injector)"
-
-/obj/item/weapon/storage/box/syndie_kit/imp_mindslave/New()
-	var/obj/item/weapon/implanter/O = new(src)
-	O.imp = new /obj/item/weapon/implant/mindslave(O)
-	O.update_icon()
-	..()
-	return
-*/

--- a/code/game/objects/items/weapons/implants/implant_mindslave.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindslave.dm
@@ -22,6 +22,10 @@
 	if(target == user)
 		target <<"<span class='notice'>You can't implant yourself!</span>"
 		return 0
+	if(isloyal(target))
+		target <<"<span class='danger'>Your loyalty implant rejects [user]'s mindslave!</span>"
+		user <<"<span class='danger'>[target] somehow rejects the mindslave implant!</span>"
+		return 0
 	if(..())
 		target << "<span class='notice'>You feel a surge of loyalty towards [user].</span>"
 		target << "<span class='userdanger'> You MUST obey any command given to you by your master(that doesn't violate any rules). You are an antag while mindslaved.</span>"

--- a/code/game/objects/items/weapons/implants/implant_mindslave.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindslave.dm
@@ -19,28 +19,31 @@
 	return dat
 
 /obj/item/weapon/implant/mindslave/implant(mob/target,mob/user)
-	if(target == user)
-		target <<"<span class='notice'>You can't implant yourself!</span>"
-		return 0
-	if(isloyal(target))
-		target <<"<span class='danger'>Your loyalty implant rejects [user]'s mindslave!</span>"
-		user <<"<span class='danger'>[target] somehow rejects the mindslave implant!</span>"
-		return 0
-	if(..())
-		target << "<span class='notice'>You feel a surge of loyalty towards [user].</span>"
-		target << "<span class='userdanger'> You MUST obey any command given to you by your master(that doesn't violate any rules). You are an antag while mindslaved.</span>"
-		target << "<span class='danger'>You CANNOT harm your master. Check your memory ( with the notes verb) if you forget who your master is.</span>"
-		var/time = 9000 + rand(60,3000)
-		timerid = addtimer(src,"remove_mindslave",time)
-		if(!target.mind.special_role)
-			target.mind.special_role = "Mindslave"
-		protect_objective = new /datum/objective/protect
-		protect_objective.owner = target.mind
-		protect_objective.target = user.mind
-		protect_objective.explanation_text = "Protect [user], your mindslave master. Obey any command given by them."
-		target.mind.objectives += protect_objective
-		message_admins("[user]/([user.ckey]) made a mindslave out of [target]/([target.ckey]).")
-		return 1
+	if(target.mind)
+		if(target == user)
+			target <<"<span class='notice'>You can't implant yourself!</span>"
+			return 0
+		if(isloyal(target))
+			target <<"<span class='danger'>Your loyalty implant rejects [user]'s mindslave!</span>"
+			user <<"<span class='danger'>[target] somehow rejects the mindslave implant!</span>"
+			return 0
+		if(..())
+			target << "<span class='notice'>You feel a surge of loyalty towards [user].</span>"
+			target << "<span class='userdanger'> You MUST obey any command given to you by your master(that doesn't violate any rules). You are an antag while mindslaved.</span>"
+			target << "<span class='danger'>You CANNOT harm your master. Check your memory ( with the notes verb) if you forget who your master is.</span>"
+			var/time = 9000 + rand(60,3000)
+			timerid = addtimer(src,"remove_mindslave",time)
+			if(!target.mind.special_role)
+				target.mind.special_role = "Mindslave"
+				ticker.mode.traitors |= target.mind
+			protect_objective = new /datum/objective/protect
+			protect_objective.owner = target.mind
+			protect_objective.target = user.mind
+			protect_objective.explanation_text = "Protect [user], your mindslave master. Obey any command given by them."
+			target.mind.objectives += protect_objective
+			message_admins("[user]/([user.ckey]) made a mindslave out of [target]/([target.ckey]).")
+			return 1
+	user <<"<span class='notice'>[target] has no mind!</span>"
 	return 0
 
 /obj/item/weapon/implant/mindslave/removed(mob/source)
@@ -57,6 +60,7 @@
 	if(imp_in)
 		if(imp_in.mind.special_role == "Mindslave")
 			imp_in.mind.special_role = ""
+			ticker.mode.traitors -= imp_in.mind
 		imp_in << "<span class='userdanger'>You feel your free will come back to you! You no longer have to obey your master!</span>"
 		imp_in << "<span class='userdanger'>If you were not an antagonist BEFORE being mindslave, then you no longer are one.</span>"
 		qdel(protect_objective)

--- a/code/game/objects/items/weapons/implants/implant_mindslave.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindslave.dm
@@ -29,7 +29,7 @@
 	if(..())
 		target << "<span class='notice'>You feel a surge of loyalty towards [user].</span>"
 		target << "<span class='userdanger'> You MUST obey any command given to you by your master(that doesn't violate any rules). You are an antag while mindslaved.</span>"
-		target << "<span class='danger'>You CANNOT harm your master.</span>"
+		target << "<span class='danger'>You CANNOT harm your master. Check your memory ( with the notes verb) if you forget who your master is.</span>"
 		var/time = 9000 + rand(60,3000)
 		timerid = addtimer(src,"remove_mindslave",time)
 		target.mind.special_role = "Mindslave"

--- a/code/game/objects/items/weapons/implants/implant_mindslave.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindslave.dm
@@ -37,9 +37,9 @@
 		protect_objective = new /datum/objective/protect
 		protect_objective.owner = target.mind
 		protect_objective.target = user.mind
-		protect_objective.explanation_text = "Protect [user], your mindslave master. Obey any command he gives."
+		protect_objective.explanation_text = "Protect [user], your mindslave master. Obey any command given by them."
 		target.mind.objectives += protect_objective
-		log_admin("[user]([user.ckey]) made a mindslave out of [target]([target.ckey]).")
+		message_admins("[user]/([user.ckey]) made a mindslave out of [target]/([target.ckey]).")
 		return 1
 	return 0
 
@@ -59,8 +59,8 @@
 			imp_in.mind.special_role = ""
 		imp_in << "<span class='userdanger'>You feel your free will come back to you! You no longer have to obey your master!</span>"
 		imp_in << "<span class='userdanger'>If you were not an antagonist BEFORE being mindslave, then you no longer are one.</span>"
-		protect_objective = null
-		log_admin("[imp_in]([imp_in.ckey]) is no longer a mindslave.")
+		qdel(protect_objective)
+		message_admins("[imp_in]/([imp_in.ckey]) is no longer a mindslave.")
 
 /obj/item/weapon/implanter/mindslave
 	name = "implanter (mind slave)"

--- a/code/game/objects/items/weapons/implants/implant_mindslave.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindslave.dm
@@ -4,7 +4,7 @@
 	origin_tech = "materials=2;biotech=4;programming=4"
 	activated = 0
 	var/timerid
-	var/slavememory
+	var/datum/objective/protect/protect_objective
 
 /obj/item/weapon/implant/mindslave/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
@@ -32,9 +32,13 @@
 		target << "<span class='danger'>You CANNOT harm your master. Check your memory ( with the notes verb) if you forget who your master is.</span>"
 		var/time = 9000 + rand(60,3000)
 		timerid = addtimer(src,"remove_mindslave",time)
-		target.mind.special_role = "Mindslave"
-		slavememory = "<b>Your mindslave master is</b>: [user]. Obey any command they give you!"
-		target.mind.store_memory(slavememory)
+		if(!target.mind.special_role)
+			target.mind.special_role = "Mindslave"
+		protect_objective = new /datum/objective/protect
+		protect_objective.owner = target.mind
+		protect_objective.target = user.mind
+		protect_objective.explanation_text = "Protect [user], your mindslave master. Obey any command he gives."
+		target.mind.objectives += protect_objective
 		return 1
 	return 0
 
@@ -50,9 +54,11 @@
 
 /obj/item/weapon/implant/mindslave/proc/remove_mindslave()
 	if(imp_in)
-		imp_in.mind.special_role = ""
-		imp_in << "<span class='userdanger'>You feel your free will come back to you! REMEMBER THAT YOU ARE NOW NO LONGER AN ANTAG, BUT YOU NO LONGER HAVE TO LISTEN TO YOUR MASTER.</span>"
-		imp_in.memory -= slavememory
+		if(imp_in.mind.special_role == "Mindslave")
+			imp_in.mind.special_role = ""
+		imp_in << "<span class='userdanger'>You feel your free will come back to you! You no longer have to obey your master!</span>"
+		imp_in << "<span class='userdanger'>If you were not an antagonist BEFORE being mindslave, then you no longer are one.</span>"
+		protect_objective = null
 
 /obj/item/weapon/implanter/mindslave
 	name = "implanter (mind slave)"

--- a/code/game/objects/items/weapons/implants/implant_mindslave.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindslave.dm
@@ -1,0 +1,78 @@
+/obj/item/weapon/implant/mindslave
+	name = "mindslave implant"
+	desc = "Now YOU too can have your very own mindslave! Pop this implant into anybody and they'll obey any command you give for a limited time."
+	origin_tech = "materials=2;biotech=4;programming=4"
+	activated = 0
+	var/timerid
+	var/slavememory
+
+/obj/item/weapon/implant/mindslave/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Syndicate Mindslave implant MK1<BR>
+				<b>Life:</b> Varies between 15 and 20 minutes.<BR>
+				<b>Important Notes:</b> Personnel injected with this device become loyal to the user and will obey any command given for a limited time.<BR>
+				<HR>
+				<b>Implant Details:</b><BR>
+				<b>Function:</b> Allows user to command anyone implanted to do whatever they want.<BR>
+				<b>Special Features:</b> Person with implant MUST obey any order you give. <BR>
+				<b>Integrity:</b> Implant will last around 15 and 20 minutes."}
+	return dat
+
+/obj/item/weapon/implant/mindslave/implant(mob/target,mob/user)
+	if(target == user)
+		target <<"<span class='notice'>You can't implant yourself!</span>"
+		return 0
+	if(..())
+		target << "<span class='notice'>You feel a surge of loyalty towards [user].</span>"
+		target << "\red You MUST obey any command given to you by your master(that doesn't violate any rules). You are an antag while mindslaved."
+		target << "\red You CANNOT harm your master."
+		var/time = 9000 + rand(60,300)
+		timerid = addtimer(src,"remove_mindslave",time)
+		target.mind.special_role = "Mindslave"
+		slavememory = "<b>Your mindslave master is</b>: [user]. Obey any command they give you!"
+		target.mind.store_memory(slavememory)
+		return 1
+	return 0
+
+/obj/item/weapon/implant/mindslave/removed(mob/source)
+	deltimer(timerid)
+	remove_mindslave()
+	..()
+
+/obj/item/weapon/implant/mindslave/Destroy()
+	deltimer(timerid)
+	remove_mindslave()
+	..()
+
+/obj/item/weapon/implant/mindslave/proc/remove_mindslave()
+	if(imp_in)
+		imp_in.mind.special_role = ""
+		imp_in << "\red You feel your free will come back to you! REMEMBER THAT YOU ARE NOW NO LONGER AN ANTAG, BUT YOU NO LONGER HAVE TO LISTEN TO YOUR MASTER."
+		imp_in.memory -= slavememory
+
+/obj/item/weapon/implanter/mindslave
+	name = "implanter (mind slave)"
+
+/obj/item/weapon/implanter/mindslave/New()
+	imp = new /obj/item/weapon/implant/mindslave(src)
+	..()
+	update_icon()
+
+/* Backup code
+/datum/uplink_item/implants/mindslave
+	name = "Mindslave Implant"
+	desc = "An implant injected into another body, forcing the vitcim to obey any command by the user for a limited time."
+	item = /obj/item/weapon/storage/box/syndie_kit/imp_mindslave
+	cost = 9
+	surplus = 20
+
+/obj/item/weapon/storage/box/syndie_kit/imp_mindslave
+	name = "Mindslave Implant (with injector)"
+
+/obj/item/weapon/storage/box/syndie_kit/imp_mindslave/New()
+	var/obj/item/weapon/implanter/O = new(src)
+	O.imp = new /obj/item/weapon/implant/mindslave(O)
+	O.update_icon()
+	..()
+	return
+*/

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -150,6 +150,18 @@
 	O.update_icon()
 	return
 
+
+/obj/item/weapon/storage/box/syndie_kit/imp_mindslave
+	name = "Mindslave Implant (with injector)"
+
+/obj/item/weapon/storage/box/syndie_kit/imp_mindslave/New()
+	var/obj/item/weapon/implanter/O = new(src)
+	O.imp = new /obj/item/weapon/implant/mindslave(O)
+	O.update_icon()
+	..()
+	return
+
+
 /obj/item/weapon/storage/box/syndie_kit/caneshotgun
 
 /obj/item/weapon/storage/box/syndie_kit/caneshotgun/New()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -155,10 +155,10 @@
 	name = "Mindslave Implant (with injector)"
 
 /obj/item/weapon/storage/box/syndie_kit/imp_mindslave/New()
+	..()
 	var/obj/item/weapon/implanter/O = new(src)
 	O.imp = new /obj/item/weapon/implant/mindslave(O)
 	O.update_icon()
-	..()
 	return
 
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -734,6 +734,7 @@
 #include "code\game\objects\items\weapons\implants\implant_explosive.dm"
 #include "code\game\objects\items\weapons\implants\implant_freedom.dm"
 #include "code\game\objects\items\weapons\implants\implant_loyality.dm"
+#include "code\game\objects\items\weapons\implants\implant_mindslave.dm"
 #include "code\game\objects\items\weapons\implants\implant_misc.dm"
 #include "code\game\objects\items\weapons\implants\implant_storage.dm"
 #include "code\game\objects\items\weapons\implants\implant_track.dm"


### PR DESCRIPTION
_Good lord I finally got this to push_

Adds mindslave implants that traitors can buy for 9 tc. When somebody is implanted with the mindslave they must obey any command given to them, and they cannot harm their master. The implant will last around 15 to 20 minutes. 

We might need to add to rules or something so players know how this stuff works. Even though mindslaves are antags, the master can not force them to do stuff against the rules (like forcing ERP, etc). Once the mindslave wears off the slave is no longer an antag, so they must go back to following non-antag rules. Also, the master is responsible for their mindslave, so if a non-antag got hold of an implant and used it on somebody, they cannot make their slave do traitorous things. 

The only check this has when implanted is on the user (you cannot implant yourself), so traitors will be able to implant other traitors. We'll need to see what kind of balances we will have to make on it.  
