### PR TITLE
Shadowling Proposed nerfs

### DIFF
--- a/html/changelogs/kokoshadownerfs.yml
+++ b/html/changelogs/kokoshadownerfs.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Kokojo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Shadowlings can't use any abilities while Shadow Walking."
+  - tweak: "Glare is now reduced by 3/10th of it's time by having eyewear."
+  - tweak: "Shadow Walk is now much, much faster, but leaves a trail of shadows behind it."
+  - tweak: "Icy veins now does not affect people with suits, but deals a little more damage overall."
+  - tweak: "Veil does not affect glowshrooms anymore."
+  - tweak: "Blindness smoke stuns a tiny bit less."
+  - tweak: "Sonic Screech confusion time reduced by 2/10th."
+  - tweak: "Thrall lesser glare now has a range of 2."


### PR DESCRIPTION
Here's what this PR does to shadowlings at the current time.

Most skill cooldown increased.
Glare is now reduced by 3/10th of it's time by having eyewear.
Shadow Walk is now much, much faster, but leaves a trail of shadows behind it.
Veil does not affect glowshrooms anymore.
Blindness smoke stuns less
Sonic Screech confusion time reduced by 2/10th.
Icy veins now does not affect people with suits, but deals a little more damage overall.
Shadowlings can't use any abilities while Shadow Walking.(Bugfix)
Thrall lesser glare now has a range of 2.

All of those nerfs are up for debate execpt the icy veins ones and using skill while another dimension.

 I do not claim to have ultimate knowledge, but I do know, as a veteran player, that I never lost as a Shadowling. I feel those nerfs are not extreme, just enough to make the Sling lose their ''edge'' that they have with their incredible variety. Being able to kill a Sling 1v1 is still impossible (unless the Sling's an idiot) but this gives more chances to people working as a Team.

![shadownerf1](https://cloud.githubusercontent.com/assets/7472150/13909510/2b6bd478-eeeb-11e5-9454-a36b5984ffa2.png)
