### PR TITLE
Increases the Autodrobe Refiller size.

### DIFF
--- a/code/game/objects/items/weapons/vending_items.dm
+++ b/code/game/objects/items/weapons/vending_items.dm
@@ -63,7 +63,7 @@
 /obj/item/weapon/vending_refill/autodrobe
 	machine_name = "AutoDrobe"
 	icon_state = "refill_costume"
-	charges = list(25, 2, 3)// of 75 standard, 6 contraband, 9 premium
+	charges = list(27, 2, 3)// of 81 standard, 6 contraband, 9 premium
 	init_charges = list(25, 2, 3)
 
 /obj/item/weapon/vending_refill/clothing


### PR DESCRIPTION
Autodrobe contains 81 standard items, refiller was outdated and as such the Jester Hat, Corgi Suit and Carp Suit would be physically impossible to acquire without admin fuckery (since you can only fit 3 refillers into one autodrobe.)

Increased the amount by 2 (previously 25 now 27), allowing those 3 items to be picked.
