### PR TITLE
Allows self-targeting with staves.

### DIFF
--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -1,5 +1,32 @@
 /obj/item/weapon/gun/magic/staff/
 	slot_flags = SLOT_BACK
+	
+/obj/item/weapon/gun/magic/staff/attack(atom/target, mob/living/user)
+	if(target == user)
+		return
+	..()
+
+/obj/item/weapon/gun/magic/staff/afterattack(atom/target, mob/living/user)
+	if(!charges)
+		shoot_with_empty_chamber(user)
+		return
+	if(target == user)
+		if(no_den_usage)
+			var/area/A = get_area(user)
+			if(istype(A, /area/wizard_station))
+				user << "<span class='warning'>You know better than to violate the security of The Den, best wait until you leave to use [src].<span>"
+				return
+			else
+				no_den_usage = 0
+		zap_self(user)
+	else
+		..()
+	update_icon()
+	
+/obj/item/weapon/gun/magic/staff/proc/zap_self(mob/living/user)
+	user.visible_message("<span class='danger'>[user] zaps \himself with [src].</span>")
+	playsound(user, fire_sound, 50, 1)
+	user.attack_log += "\[[time_stamp()]\] <b>[user]/[user.ckey]</b> zapped \himself with a <b>[src]</b>"
 
 /obj/item/weapon/gun/magic/staff/change
 	name = "staff of change"
@@ -8,6 +35,11 @@
 	ammo_type = /obj/item/ammo_casing/magic/change
 	icon_state = "staffofchange"
 	item_state = "staffofchange"
+	
+/obj/item/weapon/gun/magic/staff/change/zap_self(mob/living/user)
+	..()
+	wabbajack(user)
+	charges--
 
 /obj/item/weapon/gun/magic/staff/animate
 	name = "staff of animation"
@@ -16,6 +48,9 @@
 	ammo_type = /obj/item/ammo_casing/magic/animate
 	icon_state = "staffofanimation"
 	item_state = "staffofanimation"
+	
+/obj/item/weapon/gun/magic/staff/animate/zap_self()
+	return
 
 /obj/item/weapon/gun/magic/staff/healing
 	name = "staff of healing"
@@ -24,6 +59,12 @@
 	ammo_type = /obj/item/ammo_casing/magic/heal
 	icon_state = "staffofhealing"
 	item_state = "staffofhealing"
+	
+/obj/item/weapon/gun/magic/staff/healing/zap_self(mob/living/user)
+	user.revive()
+	user << "<span class='notice'>You feel great!</span>"
+	charges--
+	..()
 
 /obj/item/weapon/gun/magic/staff/chaos
 	name = "staff of chaos"
@@ -36,6 +77,48 @@
 	recharge_rate = 2
 	no_den_usage = 1
 
+/obj/item/weapon/gun/magic/staff/chaos/zap_self(mob/living/user)
+	var/randomize = pick("poly","door","heal","animate","teleport","fireball","death","nothing")
+	switch(randomize)
+		if("poly")
+			..()
+			wabbajack(user)
+			charges--
+		if("door")
+			charges--
+			..()
+		if("heal")
+			user.revive()
+			user << "<span class='notice'>You feel great!</span>"
+			charges--
+			..()
+		if("animate")
+			charges--
+			..()
+		if("teleport")
+			do_teleport(user, user, 10)
+			var/datum/effect_system/smoke_spread/smoke = new
+			smoke.set_up(3, user.loc)
+			smoke.start()
+			charges--
+			..()
+		if("fireball")
+			explosion(user.loc, -1, 0, 2, 3, 0, flame_range = 2)
+			charges--
+			..()
+		if("death")
+			var/message ="<span class='warning'>You irradiate yourself with pure energy! "
+			message += pick("Do not pass go. Do not collect 200 zorkmids.</span>","You feel more confident in your spell casting skills.</span>","You Die...</span>","Do you want your possessions identified?</span>")
+			user << message
+			user.adjustOxyLoss(500)
+			charges--
+			..()
+		if("nothing")
+			charges--
+			..()
+		else
+			return
+
 /obj/item/weapon/gun/magic/staff/door
 	name = "staff of door creation"
 	desc = "An artefact that spits bolts of transformative magic that can create doors in walls."
@@ -46,3 +129,6 @@
 	max_charges = 10
 	recharge_rate = 2
 	no_den_usage = 1
+	
+/obj/item/weapon/gun/magic/staff/door/zap_self()
+	return

--- a/html/changelogs/Creeper Joe - Self Target Staff.yml
+++ b/html/changelogs/Creeper Joe - Self Target Staff.yml
@@ -1,0 +1,6 @@
+author: Creeper Joe
+
+delete-after: True
+
+changes: 
+  - rscadd: "The wizard staves can now be used on yourself instantly instead of having to put the staff in your mouth"

--- a/html/changelogs/Creeper Joe - Self Target Staff.yml
+++ b/html/changelogs/Creeper Joe - Self Target Staff.yml
@@ -3,4 +3,4 @@ author: Creeper Joe
 delete-after: True
 
 changes: 
-  - rscadd: "The wizard staves can now be used on yourself instantly instead of having to put the staff in your mouth"
+  - rscadd: "All staves can now be cast on yourself, applying their effects instantly instead of having to put it in your mouth first (much like the wands)."


### PR DESCRIPTION
Wizards can now shoot themselves with most staves (besides animation and door) to apply the effects to themselves. Most notable use is using the Staff of Healing on yourself without having to stick it in your mouth first.

Chaos staff is probably incredibly shoddy (but at least doesn't cause any errors/warnings)

Uses recycled wand code.
