### PR TITLE
Fixed washing machine not updating clothes' names if the colour was changed

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -65,13 +65,12 @@
 			for(var/obj/item/clothing/I in contents)
 				I.color = wash_color //Simply recolor the items.
 
-				var/colors = list("light brown", "brown", "cyan", "fingerless", "combat", "tactical", "yellowgreen", "darkred", "lightred", "maroon", "red", "orange", "rainbow", "lightgreen", "green", "lightpurple", "purple", "gold", "darkblue", "lightblue", "aqua", "blue", "yellow", "black", "grey", "gray", "white", "latex", "nitrile", "budget insulated", "insulated", "captain's")
+				var/list/colors = list("light brown", "brown", "cyan", "fingerless", "combat", "tactical", "yellowgreen", "darkred", "lightred", "maroon", "red", "orange", "rainbow", "lightgreen", "green", "lightpurple", "purple", "gold", "darkblue", "lightblue", "aqua", "blue", "yellow", "black", "grey", "gray", "white", "latex", "nitrile", "budget insulated", "insulated", "captain's")
 			
 				for(var/old_color in colors)
 					if(findtext(I.name, old_color))
 						I.name = n_replace(I.name, old_color, wash_color)
-						I.desc = I.desc + (length(I.desc) > 0 ? " " : "") + "It looks soaked in color tincture."
-						//I.icon_state = n_replace(I.icon_state, old_color, wash_color) // This would cause issues with non-existant icons
+						I.desc = I.desc + (length(I.desc) > 0 ? " " : "") + "It looks soaked in [wash_color] tincture."
 						break
 		qdel(crayon)
 		crayon = null

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -65,13 +65,14 @@
 			for(var/obj/item/clothing/I in contents)
 				I.color = wash_color //Simply recolor the items.
 
-				var/colors = list("light brown", "brown", "yellowgreen", "darkred", "lightred", "maroon", "red", "orange", "rainbow", "lightgreen", "green", "lightpurple", "purple", "gold", "darkblue", "lightblue", "aqua", "blue", "yellow", "black", "grey", "gray", "white", "latex", "nitrile", "budget insulated", "insulated", "captain's")
-				
+				var/colors = list("light brown", "brown", "cyan", "fingerless", "combat", "tactical", "yellowgreen", "darkred", "lightred", "maroon", "red", "orange", "rainbow", "lightgreen", "green", "lightpurple", "purple", "gold", "darkblue", "lightblue", "aqua", "blue", "yellow", "black", "grey", "gray", "white", "latex", "nitrile", "budget insulated", "insulated", "captain's")
+			
 				for(var/old_color in colors)
-					if(old_color != wash_color)
+					if(findtext(I.name, old_color))
 						I.name = n_replace(I.name, old_color, wash_color)
-						//I.desc = n_replace(I.desc, old_color, wash_color) // Leaving this commented out because it could be a way to distinguish "fake" clothing and "real"
-						I.icon_state = n_replace(I.icon_state, old_color, wash_color)
+						I.desc = I.desc + (length(I.desc) > 0 ? " " : "") + "It looks soaked in color tincture."
+						//I.icon_state = n_replace(I.icon_state, old_color, wash_color) // This would cause issues with non-existant icons
+						break
 		qdel(crayon)
 		crayon = null
 

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -65,6 +65,13 @@
 			for(var/obj/item/clothing/I in contents)
 				I.color = wash_color //Simply recolor the items.
 
+				var/colors = list("light brown", "brown", "yellowgreen", "darkred", "lightred", "maroon", "red", "orange", "rainbow", "lightgreen", "green", "lightpurple", "purple", "gold", "darkblue", "lightblue", "aqua", "blue", "yellow", "black", "grey", "gray", "white", "latex", "nitrile", "budget insulated", "insulated", "captain's")
+				
+				for(var/old_color in colors)
+					if(old_color != wash_color)
+						I.name = n_replace(I.name, old_color, wash_color)
+						//I.desc = n_replace(I.desc, old_color, wash_color) // Leaving this commented out because it could be a way to distinguish "fake" clothing and "real"
+						I.icon_state = n_replace(I.icon_state, old_color, wash_color)
 		qdel(crayon)
 		crayon = null
 

--- a/html/changelogs/JohnGinnane - fixWashingMachine.yml
+++ b/html/changelogs/JohnGinnane - fixWashingMachine.yml
@@ -33,4 +33,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Clothes with certain colours in their names are updated when you put them in a washing machine with a crayon/stamp. This also means insulated gloves will now be updated to say 'red gloves'. However their descriptions remain unchanged."
+  - rscadd: "Clothes with certain colours in their names are updated when you put them in a washing machine with a crayon/stamp. For example insulated gloves washed with a red crayon will now be updated to say 'red gloves'. However their descriptions remain unchanged."

--- a/html/changelogs/JohnGinnane - fixWashingMachine.yml
+++ b/html/changelogs/JohnGinnane - fixWashingMachine.yml
@@ -33,4 +33,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Clothes with certain colours in their names are updated when you put them in a washing machine with a crayon/stamp. For example insulated gloves washed with a red crayon will now be updated to say 'red gloves'. However their descriptions remain unchanged."
+  - rscadd: "Clothes with certain colours in their names are updated when you put them in a washing machine with a crayon/stamp. For example insulated gloves washed with a red crayon will now be updated to say 'red gloves'."

--- a/html/changelogs/JohnGinnane - fixWashingMachine.yml
+++ b/html/changelogs/JohnGinnane - fixWashingMachine.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: John Ginnane
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Clothes with certain colours in their names are updated when you put them in a washing machine with a crayon/stamp. This also means insulated gloves will now be updated to say 'red gloves'. However their descriptions remain unchanged."


### PR DESCRIPTION
Most colours will be updated to match the colour of the crayon/stamp
placed in the washing machine. However the descriptions remain unchanged.

Fixes #1279
