### PR TITLE
Slight refactor of nearcrit

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -34,7 +34,7 @@
 #define GODMODE		4096
 #define FAKEDEATH	8192	//Replaces stuff like changeling.changeling_fakedeath
 #define DISFIGURED	16384	//I'll probably move this elsewhere if I ever get wround to writing a bitflag mob-damage system
-#define XENO_HOST	32768	//Tracks whether we're gonna be a baby alien's mummy.
+#define NEARCRIT	32768	//Tracks if we're in nearcrit(between 0 and -50 health)
 
 
 //Grab levels

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -110,12 +110,12 @@
 	var/turf/T = get_turf(src)
 	if (T) crewmonitor.queueUpdate(T.z)
 
-//called when a carbon changes stat, virus or XENO_HOST
+//called when a carbon changes stat, virus or has a xeno baby
 /mob/living/carbon/proc/med_hud_set_status()
 	var/image/holder = hud_list[STATUS_HUD]
 	if(stat == 2)
 		holder.icon_state = "huddead"
-	else if(status_flags & XENO_HOST)
+	else if(getorgan(/obj/item/organ/internal/body_egg/alien_embryo))
 		holder.icon_state = "hudxeno"
 	else if(check_virus())
 		holder.icon_state = "hudill"

--- a/code/game/gamemodes/handofgod/structures.dm
+++ b/code/game/gamemodes/handofgod/structures.dm
@@ -620,7 +620,7 @@
 /obj/machinery/gun_turret/defensepylon_internal_turret/should_target(atom/target)
 	if(ismob(target))
 		var/mob/M = target
-		if(!M.stat && !M.nearcrit && (!M.mind || is_in_any_team(M.mind) != faction))
+		if(!M.stat && !(M.status_flags & NEARCRIT) && (!M.mind || is_in_any_team(M.mind) != faction))
 			return 1
 	else if(istype(target, /obj/mecha))
 		var/obj/mecha/M = target

--- a/code/game/objects/items/body_egg.dm
+++ b/code/game/objects/items/body_egg.dm
@@ -17,7 +17,6 @@
 
 /obj/item/organ/internal/body_egg/Insert(var/mob/living/carbon/M, special = 0)
 	..()
-	owner.status_flags |= XENO_HOST
 	SSobj.processing |= src
 	owner.med_hud_set_status()
 	spawn(0)
@@ -26,7 +25,6 @@
 /obj/item/organ/internal/body_egg/Remove(var/mob/living/carbon/M, special = 0)
 	SSobj.processing.Remove(src)
 	if(owner)
-		owner.status_flags &= ~(XENO_HOST)
 		owner.med_hud_set_status()
 		spawn(0)
 			RemoveInfectionImages(owner)

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -147,13 +147,12 @@ Proc: AddInfectionImages()
 Des: Gives the client of the alien an image on each infected mob.
 ----------------------------------------*/
 /mob/living/carbon/alien/proc/AddInfectionImages()
-	if (client)
-		for (var/mob/living/C in mob_list)
-			if(C.status_flags & XENO_HOST)
-				var/obj/item/organ/internal/body_egg/alien_embryo/A = C.getorgan(/obj/item/organ/internal/body_egg/alien_embryo)
-				if(A)
-					var/I = image('icons/mob/alien.dmi', loc = C, icon_state = "infected[A.stage]")
-					client.images += I
+	if(client)
+		for(var/mob/living/C in mob_list)
+			var/obj/item/organ/internal/body_egg/alien_embryo/A = C.getorgan(/obj/item/organ/internal/body_egg/alien_embryo)
+			if(A)
+				var/I = image('icons/mob/alien.dmi', loc = C, icon_state = "infected[A.stage]")
+				client.images += I
 	return
 
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -61,7 +61,7 @@
 					if(gender == FEMALE)
 						sound = pick('sound/misc/cough_f1.ogg', 'sound/misc/cough_f2.ogg', 'sound/misc/cough_f3.ogg')
 					playsound(src.loc, sound, 50, 1, 5)
-					if(nearcrit)
+					if(status_flags & NEARCRIT)
 						message = "<B>[src]</B> coughs painfuly!"
 					else
 						message = "<B>[src]</B> coughs!"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -267,7 +267,7 @@
 	if(!appears_dead)
 		if(stat == UNCONSCIOUS)
 			msg += "[t_He] [t_is]n't responding to anything around [t_him] and seems to be asleep.\n"
-		else if(nearcrit)
+		else if(status_flags & NEARCRIT)
 			msg += "[t_He] appears to be incapacitated and is struggling to breathe.\n"
 		else if(getBrainLoss() >= 60)
 			msg += "[t_He] [t_has] a stupid expression on [t_his] face.\n"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -885,7 +885,7 @@
 				mspeed += 1.5
 			if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
 				mspeed += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
-			if(H.nearcrit) //This is for crawling
+			if(H.status_flags & NEARCRIT) //This is for crawling
 				mspeed += 30 //Can crawl only every 3 seconds pretty much
 
 			mspeed += speedmod

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -256,14 +256,14 @@
 			return
 
 		if(health <= config.health_threshold_crit)
-			nearcrit = 1
+			status_flags |= NEARCRIT
 			if(stat != DEAD && !(status_flags & FAKEDEATH))
 				Weaken(3)
 				if(prob(15))
 					spawn(0)
 						emote(pick("moan", "cough", "groan", "whimper"))
 		else
-			nearcrit = 0
+			status_flags &= ~NEARCRIT
 
 		if(getOxyLoss() > 50 || health <= -50)
 			Paralyse(3)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -79,7 +79,7 @@
 
 		if ("faint","faints")
 			message = "<B>[src]</B> faints."
-			if(src.sleeping || src.nearcrit)
+			if(sleeping || (status_flags & NEARCRIT))
 				return //Can't faint while asleep
 			src.sleeping += 10 //Short-short nap
 			m_type = 1

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -60,3 +60,7 @@
 	var/float_y = 0
 	var/float_ticks = 0
 	var/doing_something = 0 //Doing something? pulling out a teeth?
+
+	var/crit_can_crawl = 0 //whether or not the mob can crawl in crit
+	var/crit_crawl_damage = 0 //No damage by default
+	var/crit_crawl_damage_type = OXY

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -75,7 +75,7 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 		return
 
 	var/message_mode = get_message_mode(message)
-	if(nearcrit && stat == CONSCIOUS)
+	if((status_flags & NEARCRIT) && stat == CONSCIOUS)
 		whisper(message)
 		adjustOxyLoss(1)
 		// radio_return = NOPASS

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -22,7 +22,6 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	speed = -1
 	stop_automated_movement = 1
-	status_flags = 0
 	faction = list("cult")
 	status_flags = CANPUSH
 	flying = 1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -742,12 +742,12 @@ var/list/slot_equipment_priority = list( \
 	else if(pinned_to)
 		lying = 0
 	else if(grabbed) //Hostage hold -- the meatshield will only fall down if they're incapacitated/unconscious/dead
-		lying = 90*(nearcrit || stat || (status_flags & FAKEDEATH))
+		lying = 90*((status_flags & NEARCRIT ? 1 : 0) || stat || (status_flags & FAKEDEATH))
 	else
 		if((ko || resting) && !lying)
 			fall(ko)
 	canmove = !(ko || resting || stunned || buckled || pinned_to)
-	if(nearcrit && !stat)
+	if((status_flags & NEARCRIT) && !stat)
 		canmove = !(stunned || buckled || pinned_to)
 	density = !lying
 	if(lying)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -159,8 +159,3 @@
 	var/permanent_sight_flags = 0
 
 	var/resize = 1 //Badminnery resize
-
-	var/nearcrit = 0 //for newcrit
-	var/crit_can_crawl = 0 //whether or not the mob can crawl in crit
-	var/crit_crawl_damage = 0 //No damage by default
-	var/crit_crawl_damage_type = OXY

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -176,20 +176,20 @@
 				move_delay += config.walk_speed
 		move_delay += mob.movement_delay()
 
-		if(mob.nearcrit && mob.crit_can_crawl) //You can only crawl in nearcrit
-			if(istype(mob, /mob/living))
-				var/mob/living/L = mob
-				if(mob.crit_crawl_damage != 0) // let 'em have their negative values
-					L.apply_damage(mob.crit_crawl_damage, mob.crit_crawl_damage_type)
-			if(mob.dir == WEST)
-				mob.lying = 270
-				mob.update_canmove()
-			else if(mob.dir == EAST)
-				mob.lying = 90
-				mob.update_canmove()
-			playsound(mob.loc, pick('sound/effects/bodyscrape-01.ogg', 'sound/effects/bodyscrape-02.ogg'), 20, 1, -4) //Crawling is VERY quiet
-			mob.visible_message("<span class='danger'>[mob] crawls forward!</span>", \
-								"<span class='userdanger'>You crawl forward at the expense of some of your strength.</span>")
+		if(isliving(mob))
+			var/mob/living/L = mob
+			if((L.status_flags & NEARCRIT) && L.crit_can_crawl) //You can only crawl in nearcrit
+				if(L.crit_crawl_damage != 0) // let 'em have their negative values
+					L.apply_damage(L.crit_crawl_damage, L.crit_crawl_damage_type)
+				if(L.dir == WEST)
+					L.lying = 270
+					L.update_canmove()
+				else if(L.dir == EAST)
+					L.lying = 90
+					L.update_canmove()
+				playsound(L.loc, pick('sound/effects/bodyscrape-01.ogg', 'sound/effects/bodyscrape-02.ogg'), 20, 1, -4) //Crawling is VERY quiet
+				L.visible_message("<span class='danger'>[L] crawls forward!</span>", \
+									"<span class='userdanger'>You crawl forward at the expense of some of your strength.</span>")
 
 		if(config.Tickcomp)
 			move_delay -= 1.3


### PR DESCRIPTION
Removes pointless XENO_HOST define,replaced with NEARCRIT which replaced the "nearcrit" snowflakey var. also made nearcrit vars be owned by livings, not mobs
