### PR TITLE
Mulebot and Door crush logging; Proxycheck note

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -782,6 +782,7 @@ var/global/mulebot_count = 0
 	B.add_blood_list(H)
 	add_blood_list(H)
 	bloodiness += 4
+	add_logs(H, src, "ran over")
 
 // player on mulebot attempted to move
 /obj/machinery/bot/mulebot/relaymove(mob/user)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -782,7 +782,7 @@ var/global/mulebot_count = 0
 	B.add_blood_list(H)
 	add_blood_list(H)
 	bloodiness += 4
-	add_logs(H, src, "ran over")
+	add_logs(src, H, "ran over")
 
 // player on mulebot attempted to move
 /obj/machinery/bot/mulebot/relaymove(mob/user)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -255,7 +255,7 @@
 		else //for simple_animals & borgs
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
 			playsound(L.loc, 'sound/effects/bang.ogg', 60, 1)
-		add_logs(L, src, "crushed")
+		add_logs(src, L, "crushed")
 		var/turf/location = src.loc
 		if(istype(location, /turf/simulated)) //add_blood doesn't work for borgs/xenos, but add_blood_floor does.
 			location.add_blood_floor(L)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -255,6 +255,7 @@
 		else //for simple_animals & borgs
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
 			playsound(L.loc, 'sound/effects/bang.ogg', 60, 1)
+		add_logs(L, src, "crushed")
 		var/turf/location = src.loc
 		if(istype(location, /turf/simulated)) //add_blood doesn't work for borgs/xenos, but add_blood_floor does.
 			location.add_blood_floor(L)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -191,6 +191,7 @@ var/next_external_rsc = 0
 		if(config.proxykick) // proxyban's enabled
 			var/danger = proxycheck()
 			if(danger >= text2num(config.proxykicklimit))
+				add_note(ckey, "[danger*100]% chance to be a proxy user", null, "Proxycheck", 0)
 				log_access("Failed Login: [key] - New account attempting to connect with a proxy([danger*100]% possibility to be a proxy.)")
 				message_admins("<span class='adminnotice'>Failed Login: [key] - with a proxy([danger*100]% possibility to be a proxy.</span>")
 				src << "Sorry but you're not allowed to connect to the server through a proxy. Disable it and reconnect if you want to play."


### PR DESCRIPTION
Adds logging to mulebot runover proc and Door/shutters crush proc. Also makes proxycheck add a note to a ckey if it's positive to proxy using.
