### PR TITLE
Wrestling Belt traitor item, CQC gloves buff

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -459,6 +459,12 @@ var/list/uplink_items = list()
 	item = /obj/item/clothing/gloves/cqc
 	cost = 12
 
+/datum/uplink_item/dangerous/wrestling
+	name = "Wrestling Belt"
+	desc = "A powerful wrestling moveset given to you via championship belt."
+	item = /obj/item/weapon/storage/belt/champion/wrestling
+	cost = 12
+
 /datum/uplink_item/dangerous/reinforcement
 	name = "Reinforcements"
 	desc = "Call in an additional team member. They come with predefined gear sets, but you might want to save some telecrystals to arm them better."

--- a/code/modules/martial arts/cqc.dm
+++ b/code/modules/martial arts/cqc.dm
@@ -10,7 +10,7 @@
 	usr << "<b><i>You remember the training from your former mentor...</i></b>"
 	usr << "<span class='notice'>Roundhouse Kick</span>: Punch 5 times. Knocks the opponent unconscious."
 	usr << "<span class='notice'>Robust Disarm</span>: Your disarms have no push chance, however, when you disarm someone the weapon is instantly put in your hands."
-	usr << "<span class='notice'>Clinch</span>: Grab. 50% chance to instantly grab your opponent into aggressive. Can be reinforced into neckgrab quickly."
+	usr << "<span class='notice'>Clinch</span>: Grab. 100% chance to instantly grab your opponent into aggressive. Can be reinforced into neckgrab quickly."
 	usr << "<span class='notice'>Half-wing Choke</span>: Replaces normal choking. Faster to perform, also gives 20 staminaloss to opponent on attempted choke."
 	usr << "<span class='notice'>Legsweep</span>: Harm intent w/ AGGRESSIVE grab in active hand. Cannot be performed on downed opponent. Sweeps the opponent off their feet for a while. Useful if you failed a clinch."
 	usr << "<span class='notice'>Karate Chop</span>: Disarm intent w/ NECK grab in active hand. Cannot be performed on downed opponent. Makes target dizzy, gives them 20 staminaloss."
@@ -138,15 +138,16 @@
 	D.grabbedby(A,1)
 	var/obj/item/weapon/grab/G = A.get_active_hand()
 	if(G)
-		if(A.dir == D.dir || prob(50)) //100% chance to clinch when attacking from behind, otherwise it's 50% chance
-			G.state = GRAB_AGGRESSIVE
-			D.visible_message("<span class='danger'>[A] has [D] in a clinch! (Aggressive Grab)</span>", \
-									"<span class='userdanger'>[A] has [D] in a clinch! (Aggressive Grab)</span>")
-			add_logs(A, D, "aggro-grabbed", addition="(CQC)")
-		else
-			D.visible_message("<span class='danger'>[A] holds [D] down! (Passive Grab)</span>", \
-										"<span class='userdanger'>[A] holds [D] down (Passive Grab)!</span>")
-			add_logs(A, D, "grabbed", addition="(CQC)")
+		// if(A.dir == D.dir || prob(50)) //~100% chance to clinch when attacking from behind, otherwise it's 50% chance~
+		//100% grab chance due to CQC gloves being too awkward and finicky otherwise. Much needed buff IMO.
+		G.state = GRAB_AGGRESSIVE
+		D.visible_message("<span class='danger'>[A] has [D] in a clinch! (Aggressive Grab)</span>", \
+								"<span class='userdanger'>[A] has [D] in a clinch! (Aggressive Grab)</span>")
+		add_logs(A, D, "aggro-grabbed", addition="(CQC)")
+		// else
+		// 	D.visible_message("<span class='danger'>[A] holds [D] down! (Passive Grab)</span>", \
+		// 								"<span class='userdanger'>[A] holds [D] down (Passive Grab)!</span>")
+		// 	add_logs(A, D, "grabbed", addition="(CQC)")
 	return 1
 
 /datum/martial_art/cqc/grab_reinforce_act(obj/item/weapon/grab/G, mob/living/carbon/human/A, mob/living/carbon/human/D)

--- a/code/modules/martial arts/wrestling.dm
+++ b/code/modules/martial arts/wrestling.dm
@@ -356,7 +356,7 @@ You can also climb tables by dragging and dropping yourself on them!<br>
 	armor_block = D.run_armor_check(affecting, "melee")
 	D.apply_damage(40, damtype, affecting, armor_block)
 	D.emote("scream")
-	D.apply_effect(7, WEAKEN)//, armor_block) //You got FUCKED UP.
+	D.apply_effect(7, PARALYZE) //If you let yourself tombstoned you don't deserve a chance to fight back with superfart.
 	for(var/mob/M in range(4, D)) //Shaky camera effect
 		if(!M.stat && !istype(M, /mob/living/silicon/ai))
 			shake_camera(M, 3, 1)
@@ -388,7 +388,7 @@ You can also climb tables by dragging and dropping yourself on them!<br>
 	armor_block = D.run_armor_check(affecting, "melee")
 	D.apply_damage(35, damtype, affecting, armor_block)
 	D.emote("scream")
-	D.apply_effect(7, WEAKEN)//, armor_block)
+	D.apply_effect(7, PARALYZE) //You get fucking ELBOW DROPPED right on your temple from a fucking table, you better be KO'd (this is a measure to prevent superfart retaliation)
 	playsound(D, pick("swing_hit"), 60, 1)
 	add_logs(A, D, "corkscrew elbow dropped", addition="(Wrassling)")
 	for(var/mob/M in range(3, D)) //Shaky camera effect
@@ -424,7 +424,7 @@ You can also climb tables by dragging and dropping yourself on them!<br>
 	armor_block = D.run_armor_check(affecting, "melee")
 	D.apply_damage(25, damtype, affecting, armor_block)
 	D.emote("scream")
-	D.apply_effect(7, WEAKEN)//, armor_block)
+	D.apply_effect(7, PARALYZE) //Special, hard-to-perform move. Victim needs to stay KO'd to prevent a cheap superfart.
 	playsound(D, pick("swing_hit"), 60, 1)
 	add_logs(A, D, "RKO'd", addition="(Wrassling)")
 	for(var/mob/M in range(3, D)) //Shaky camera effect
@@ -457,7 +457,7 @@ You can also climb tables by dragging and dropping yourself on them!<br>
 	D.apply_damage(15, damtype, affecting, armor_block) //Doesn't do too much damage compared to other moves
 	D.apply_damage(30, STAMINA, affecting, armor_block) //Still does stamina damage to compensate (to the victim)
 	D.do_bounce_anim_dir(NORTH, 2, 4, easein = BACK_EASING, easeout = BOUNCE_EASING)
-	D.apply_effect(7, WEAKEN)//, armor_block)
+	D.apply_effect(7, WEAKEN) //Special, hard-to-perform move. Victim needs to stay KO'd to prevent a cheap superfart.
 	playsound(D, 'sound/weapons/push_hard.ogg', 60, 1) //Sound signalises that this is not a high-damage attack
 	add_logs(A, D, "moonsaulted", addition="(Wrassling)")
 	for(var/mob/M in range(2, D)) //Shaky camera effect

--- a/code/modules/martial arts/wrestling.dm
+++ b/code/modules/martial arts/wrestling.dm
@@ -188,8 +188,8 @@ You can also climb tables by dragging and dropping yourself on them!<br>
 	var/obj/item/organ/limb/affecting = D.get_organ("chest")
 	var/armor_block = D.run_armor_check(affecting, "melee")
 	D.apply_effect(5, WEAKEN)//, armor_block)
-	A.SpinAnimation(6,1, easeout = ELASTIC_EASING)
-	D.SpinAnimation(6,1, easeout = ELASTIC_EASING)
+	A.SpinAnimation(6,1)
+	D.SpinAnimation(6,1)
 	sleep(3)
 	if(!A || A.stat || !D || !A.Adjacent(D)) return
 	D.forceMove(A.loc)
@@ -352,7 +352,6 @@ You can also climb tables by dragging and dropping yourself on them!<br>
 	var/obj/item/organ/limb/affecting = A.get_organ("chest")
 	var/armor_block = A.run_armor_check(affecting, "melee")
 	A.apply_effect(5, WEAKEN)//, armor_block)
-	A.apply_damage(40, STAMINA, affecting, armor_block) //This move will take lots of your stamina as a balancing measure
 	affecting = D.get_organ("head")
 	armor_block = D.run_armor_check(affecting, "melee")
 	D.apply_damage(40, damtype, affecting, armor_block)
@@ -385,7 +384,6 @@ You can also climb tables by dragging and dropping yourself on them!<br>
 	var/obj/item/organ/limb/affecting = A.get_organ("chest")
 	var/armor_block = A.run_armor_check(affecting, "melee")
 	A.apply_effect(5, WEAKEN)//, armor_block)
-	A.apply_damage(30, STAMINA, affecting, armor_block)
 	affecting = D.get_organ("chest")
 	armor_block = D.run_armor_check(affecting, "melee")
 	D.apply_damage(35, damtype, affecting, armor_block)
@@ -422,7 +420,6 @@ You can also climb tables by dragging and dropping yourself on them!<br>
 	var/obj/item/organ/limb/affecting = A.get_organ("chest")
 	var/armor_block = A.run_armor_check(affecting, "melee")
 	A.apply_effect(5, WEAKEN)//, armor_block)
-	A.apply_damage(30, STAMINA, affecting, armor_block)
 	affecting = D.get_organ("chest")
 	armor_block = D.run_armor_check(affecting, "melee")
 	D.apply_damage(25, damtype, affecting, armor_block)
@@ -454,12 +451,11 @@ You can also climb tables by dragging and dropping yourself on them!<br>
 	var/obj/item/organ/limb/affecting = A.get_organ("chest")
 	var/armor_block = A.run_armor_check(affecting, "melee")
 	A.apply_effect(5, WEAKEN)//, armor_block)
-	A.apply_damage(10, STAMINA, affecting, armor_block)
 	A.do_bounce_anim_dir(NORTH, 2, 6, easein = BACK_EASING, easeout = BOUNCE_EASING)
 	affecting = D.get_organ("chest")
 	armor_block = D.run_armor_check(affecting, "melee")
 	D.apply_damage(15, damtype, affecting, armor_block) //Doesn't do too much damage compared to other moves
-	D.apply_damage(30, STAMINA, affecting, armor_block) //Still does stamina damage to compensate
+	D.apply_damage(30, STAMINA, affecting, armor_block) //Still does stamina damage to compensate (to the victim)
 	D.do_bounce_anim_dir(NORTH, 2, 4, easein = BACK_EASING, easeout = BOUNCE_EASING)
 	D.apply_effect(7, WEAKEN)//, armor_block)
 	playsound(D, 'sound/weapons/push_hard.ogg', 60, 1) //Sound signalises that this is not a high-damage attack

--- a/html/changelogs/Crystalwarrior160 - MartialArts1.yml
+++ b/html/changelogs/Crystalwarrior160 - MartialArts1.yml
@@ -1,0 +1,9 @@
+author: Crystalwarrior160
+
+delete-after: True
+
+changes: 
+  - tweak: "Made CQC gloves have 100% clinch chance"
+  - tweak: "Removed stamina damage applied to attacker for Wrestling Belt"
+  - rscadd: "Wrestling Belt is now an uplink item! Costs 12 TC, same as CQC gloves"
+  - bugfix: "Fixed runtime error with Wrestling Belt"

--- a/html/changelogs/Crystalwarrior160 - MartialArts1.yml
+++ b/html/changelogs/Crystalwarrior160 - MartialArts1.yml
@@ -5,5 +5,6 @@ delete-after: True
 changes: 
   - tweak: "Made CQC gloves have 100% clinch chance"
   - tweak: "Removed stamina damage applied to attacker for Wrestling Belt"
+  - tweak: "Made some hard-to-perform Wrestling special moves/finishers cause the victim to be KO'd so you can't have a cheap superfart"
   - rscadd: "Wrestling Belt is now an uplink item! Costs 12 TC, same as CQC gloves"
   - bugfix: "Fixed runtime error with Wrestling Belt"


### PR DESCRIPTION
Changes: 
-  - tweak: "Made CQC gloves have 100% clinch chance"
-  - tweak: "Removed stamina damage applied to attacker for Wrestling Belt"
-  - rscadd: "Wrestling Belt is now an uplink item! Costs 12 TC, same as CQC gloves"
-  - bugfix: "Fixed runtime error with Wrestling Belt" 

CQC gloves are still hard to use especially on aware opponents. 100% clinch chance makes surprise attacks not depend on awkward directions and RNG but instead relies on your speed alone.
Wrestling belt is added as a traitor weapon as well for the same price of 12 TC.
Wrestling Belt received a buff since initially it was designed for civvie use but now it can be very viable in 1v1 situations. Stamina drain for some of the special moves was removed.
