### PR TITLE
Fixed stuns being 100% blocked by any energy armor value

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -19,9 +19,9 @@
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 7
 
-/obj/item/projectile/energy/electrode/on_hit(atom/target, blocked = 0)
+/obj/item/projectile/energy/electrode/on_hit(atom/target, blocked = 0, hit_zone)
 	. = ..()
-	if(!ismob(target) || blocked >= 2) //Fully blocked by mob or collided with dense object - burst into sparks!
+	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
 		var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
 		sparks.set_up(1, 1, src)
 		sparks.start()

--- a/html/changelogs/Crystalwarrior160 - tgpls.yml
+++ b/html/changelogs/Crystalwarrior160 - tgpls.yml
@@ -1,0 +1,6 @@
+author: Crystalwarrior160
+
+delete-after: True
+
+changes: 
+  - bugfix: "FIXED STUNS BEING COMPLETELY BLOCKED BY ARMOR. Blame /tg/ for that one. I'm serious! :V"


### PR DESCRIPTION
fixed an incredibly strange and stupid bug causing stuns to be 100% useless against armor with ANY anti-stun value.

Also fixed electrodes exploding in sparks while hitting armor unless 100% blocked (pre-crawl update issue that was not as noticeable)

also add "tg fucked up" label pls :^)
