### PR TITLE
Throwing and Baseball fixes/tweaks

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -3,6 +3,7 @@
 	var/last_move = null
 	var/anchored = 0
 	var/throwing = 0
+	var/throwing_def_zone = ""
 	var/throw_speed = 2
 	var/throw_range = 7
 	var/mob/pulledby = null
@@ -165,11 +166,12 @@
 		step(src, AM.dir)
 	..()
 
-/atom/movable/proc/throw_at(atom/target, range, speed, spin=1, diagonals_first = 0)
+/atom/movable/proc/throw_at(atom/target, range, speed, spin=1, diagonals_first = 0, def_zone)
 	if(!target || !src || (flags & NODROP))	return 0
 	//use a modified version of Bresenham's algorithm to get from the atom's current position to that of the target
 
 	throwing = 1
+	throwing_def_zone = def_zone
 	if(spin) //if we don't want the /atom/movable to spin.
 		SpinAnimation(5, 1)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -534,10 +534,11 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	A.hitby(src, 0, itempush)
 	if(mult)
 		throwforce = initial(throwforce)
+		throwing_def_zone = ""
 		mult = 0
 	return
 
-/obj/item/throw_at(atom/target, range, speed, spin=1)
+/obj/item/throw_at(atom/target, range, speed, spin=1, diagonals_first, def_zone)
 	. = ..()
 	throw_speed = initial(throw_speed) //explosions change this.
 

--- a/code/game/objects/items/weapons/baseball.dm
+++ b/code/game/objects/items/weapons/baseball.dm
@@ -67,19 +67,26 @@
 	user.visible_message("<span class='suicide'>[user] smashes the baseball bat into \his head! It looks like \he's trying to commit suicide..</span>")
 	return (BRUTELOSS)
 
-/mob/living/carbon/human/hitby(atom/movable/AM, zone)
+/mob/living/carbon/human/hitby(atom/movable/AM, skipcatch, hitpush = 1, blocked = 0, zone)
 	..()
 	var/obj/item/baseball/I = AM
 	if(!istype(I))
 		return
-	if(!zone)
-		zone = ran_zone("chest", 50)
+	if(zone == "")
+		zone = ran_zone("chest", 65)
 	var/armor = getarmor(get_organ(check_zone(zone), "melee"))
 	if(armor >= 100) return
 	if(zone == "head" && I.throwforce >= 6) //This is kind of a terrible way to check if the baseball was batted but whatever
-		if(stat == CONSCIOUS && prob(50) && armor < 40) //High chance to make up for the already-RNG zone picking
-			visible_message("<span class='danger'>[src] has been knocked unconscious!</span>", \
-							"<span class='userdanger'>[src] has been knocked unconscious!</span>")
-			apply_effect(10, PARALYZE, armor) //Since it's ranged, we don't want to make KO too OP
-			ticker.mode.remove_revolutionary(mind)
-			ticker.mode.remove_gangster(mind)
+		if(stat == CONSCIOUS && prob(50)) //decent chance to make up for the already-RNG zone picking
+			if(armor < 40) //It only KO's you if you don't have head armor
+				visible_message("<span class='danger'>[src] has been knocked unconscious!</span>", \
+								"<span class='userdanger'>[src] has been knocked unconscious!</span>")
+				apply_effect(6, PARALYZE, armor) //Since it's ranged, we don't want to make KO too OP
+				if(prob(50))
+					ticker.mode.remove_revolutionary(mind)
+					ticker.mode.remove_gangster(mind)
+			else //Knock them down instead
+				visible_message("<span class='danger'>[src] has been knocked down!</span>", \
+								"<span class='userdanger'>[src] has been knocked down!</span>")
+				apply_effect(5, WEAKEN, armor)
+				apply_effect(3, STUN, armor)

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -103,12 +103,13 @@
 			loadedItems.Remove(ITD)
 			loadedWeightClass -= ITD.w_class
 			ITD.throw_speed = pressureSetting * 2
+			ITD.throwforce += 1 //So things like baseballs actually can KO and stuff
 			ITD.loc = get_turf(src)
-			ITD.throw_at(target, pressureSetting * 5, pressureSetting * 2)
+			ITD.throw_at(target, pressureSetting * 5, pressureSetting * 2, def_zone=user.zone_sel.selecting)
 	if(pressureSetting >= 3)
 		user.visible_message("<span class='warning'>[user] is thrown down by the force of the cannon!</span>", "<span class='userdanger'>[src] slams into your shoulder, knocking you down!")
 		user.Weaken(2)
-
+		user.Stun(2)
 
 /obj/item/weapon/pneumatic_cannon/ghetto //Obtainable by improvised methods; more gas per use, less capacity, but smaller
 	name = "improvised pneumatic cannon"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -287,7 +287,7 @@
 
 		newtonian_move(get_dir(target, src))
 
-		item.throw_at(target, range, throw_speed)
+		item.throw_at(target, range, throw_speed, def_zone = zone_sel.selecting)
 
 /mob/living/carbon/restrained()
 	if (handcuffed)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -411,12 +411,13 @@ emp_act
 	else
 		..()
 
-/mob/living/carbon/human/hitby(atom/movable/AM, skipcatch = 0, hitpush = 1, blocked = 0)
+/mob/living/carbon/human/hitby(atom/movable/AM, skipcatch = 0, hitpush = 1, blocked = 0, zone)
 	var/obj/item/I
 	var/throwpower = 30
 	if(istype(AM, /obj/item))
 		I = AM
 		throwpower = I.throwforce
+		zone = ran_zone(I.throwing_def_zone, 65)
 	if(check_shields(throwpower, "\the [AM.name]", AM, 1))
 		hitpush = 0
 		skipcatch = 1
@@ -434,12 +435,13 @@ emp_act
 		if(can_embed(I) || I.assthrown)
 			if((!in_throw_mode || get_active_hand()) && (prob(I.embed_chance) && !(dna && (PIERCEIMMUNE in dna.species.specflags))) || I.assthrown)
 				throw_alert("embeddedobject", /obj/screen/alert/embeddedobject)
-				var/obj/item/organ/limb/L = pick(organs)
-				L.embedded_objects |= I
-				I.add_blood(src)//it embedded itself in you, of course it's bloody!
-				I.loc = src
-				L.take_damage(I.w_class*I.embedded_impact_pain_multiplier)
-				visible_message("<span class='danger'>\The [I.name] embeds itself in [src]'s [L.getDisplayName()]!</span>","<span class='userdanger'>\The [I.name] embeds itself in your [L.getDisplayName()]!</span>")
-				hitpush = 0
-				skipcatch = 1 //can't catch the now embedded item
-	return ..(I, skipcatch, hitpush, blocked)
+				var/obj/item/organ/limb/L = get_organ(check_zone(zone))
+				if(istype(L))
+					L.embedded_objects |= I
+					I.add_blood(src)//it embedded itself in you, of course it's bloody!
+					I.loc = src
+					L.take_damage(I.w_class*I.embedded_impact_pain_multiplier)
+					visible_message("<span class='danger'>\The [I.name] embeds itself in [src]'s [L.getDisplayName()]!</span>","<span class='userdanger'>\The [I.name] embeds itself in your [L.getDisplayName()]!</span>")
+					hitpush = 0
+					skipcatch = 1 //can't catch the now embedded item
+	return ..(I, skipcatch, hitpush, blocked, zone)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -44,10 +44,11 @@
 		else
 				return 0
 
-/mob/living/hitby(atom/movable/AM, skipcatch, hitpush = 1, blocked = 0)
+/mob/living/hitby(atom/movable/AM, skipcatch, hitpush = 1, blocked = 0, zone)
 	if(istype(AM, /obj/item))
 		var/obj/item/I = AM
-		var/zone = ran_zone("chest", 65)//Hits a random part of the body, geared towards the chest
+		if(zone == "")
+			zone = ran_zone(I.throwing_def_zone, 65)//Hits a random part of the body, geared towards the item's throwing_def_zone
 		var/dtype = BRUTE
 		var/volume = vol_by_throwforce_and_or_w_class(I)
 		if(istype(I,/obj/item/weapon)) //If the item is a weapon...
@@ -67,13 +68,13 @@
 		if(!I.throwforce)// Otherwise, if the item's throwforce is 0...
 			playsound(loc, 'sound/weapons/throwtap.ogg', 1, volume, -1)//...play throwtap.ogg.
 		if(!blocked)
-			visible_message("<span class='danger'>[src] has been hit by [I].</span>", \
-							"<span class='userdanger'>[src] has been hit by [I].</span>")
+			visible_message("<span class='danger'>[src] has been hit by [I] in \the [parse_zone(zone)].</span>", \
+							"<span class='userdanger'>[src] has been hit by [I] in \the [parse_zone(zone)].</span>")
 			var/armor = run_armor_check(zone, "melee", "Your armor has protected your [parse_zone(zone)].", "Your armor has softened hit to your [parse_zone(zone)].",I.armour_penetration)
 			apply_damage(I.throwforce, dtype, zone, armor, I)
 	else
 		playsound(loc, 'sound/weapons/genhit.ogg', 50, 1, -1)
-	..()
+	..(AM, skipcatch, hitpush, blocked, zone)
 
 /mob/living/mech_melee_attack(obj/mecha/M)
 	if(M.occupant.a_intent == "harm")

--- a/html/changelogs/Crystalwarrior160 - Throwfix.yml
+++ b/html/changelogs/Crystalwarrior160 - Throwfix.yml
@@ -1,0 +1,8 @@
+author: Crystalwarrior160
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed thrown items not tracking the thrower's selected zone"
+  - tweak: "Pneumatic Cannon can now be aimed at limbs"
+  - tweak: "Tweaked baseballs - nerfed paralysis duration but also made it so if you have sufficient armor you can still get weakened"


### PR DESCRIPTION
Fixed thrown items not tracking the thrower's selected zone
Pneumatic Cannon can now be aimed at limbs
Tweaked baseballs - nerfed paralysis duration but also made it so if you have sufficient armor you can still get weakened
Made embedding depend on what limb was ACTUALLY hit instead of random
