### PR TITLE
Made space lube able to be chained

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -282,17 +282,27 @@
 		C.Stun(s_amount)
 		C.Weaken(w_amount)
 		C.stop_pulling()
+		if(C.lying != oldlying) //did we actually fall?
+			var/dam_zone = pick("chest", "l_hand", "r_hand", "l_leg", "r_leg")
+			C.apply_damage(2, BRUTE, dam_zone)
+
 		if(buckled_obj)
 			buckled_obj.unbuckle_mob()
 			step(buckled_obj, olddir)
 		else if(lube&SLIDE)
-			for(var/i=1, i<5, i++)
-				spawn (i)
-					step(C, olddir)
+			var/i = 1
+			var/l = 0
+			while(i < 5 && l < 64) //Only 64 loops are allowed max to prevent infinite looping
+				l++
+				if(l%5==0)
 					C.spin(1,1)
-		if(C.lying != oldlying) //did we actually fall?
-			var/dam_zone = pick("chest", "l_hand", "r_hand", "l_leg", "r_leg")
-			C.apply_damage(2, BRUTE, dam_zone)
+				var/turf/simulated/T = get_turf(C)
+				if(!istype(T) || T.wet != TURF_WET_LUBE)
+					i++
+				step(C, olddir)
+				if(get_turf(C) == T) //We haven't moved an inch...
+					break //Probably hit an obstacle, our sliding was interrupted.
+				sleep (i)
 		return 1
 
 /turf/singularity_act()

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -131,7 +131,7 @@
 	var/CT = cooling_temperature
 	if(reac_volume >= 10)
 		var/time = min(reac_volume*100, 790) // 10 second per unit, max is 790 aka default value
-		T.MakeSlippery(1, time)
+		T.MakeSlippery(TURF_WET_WATER, time)
 
 	for(var/mob/living/simple_animal/slime/M in T)
 		M.apply_water()
@@ -267,7 +267,7 @@
 	if (!istype(T)) return
 	if(reac_volume >= 10)
 		var/time = min(reac_volume*100, 790) // 10 second per unit, max is 790 aka default value
-		T.MakeSlippery(2, time)
+		T.MakeSlippery(TURF_WET_LUBE, time)
 
 /datum/reagent/spraytan
 	name = "Spray Tan"

--- a/html/changelogs/Crystalwarrior160 - LUBEFUN.yml
+++ b/html/changelogs/Crystalwarrior160 - LUBEFUN.yml
@@ -1,0 +1,6 @@
+author: Crystalwarrior160
+
+delete-after: True
+
+changes: 
+  - rscadd: "Lube can now be chained. That means if you have a hallway of lube people will keep going and going until the lube ends or until they've travelled 64 tiles."


### PR DESCRIPTION
Lube can now be chained. That means if you have a hallway of lube people will keep going and going until the lube ends or until they've travelled 64 tiles.

Note that if https://github.com/HippieStationCode/HippieStation13/pull/2142 gets merged it also means lube can be crawled through safely, but you'll still be incredibly slow - slower than walking in fact.
