### PR TITLE
Make dm.sh fail on DM warnings

### DIFF
--- a/dm.sh
+++ b/dm.sh
@@ -68,13 +68,21 @@ then
 		exit 3
 	fi
 	
-	"$dm" $dmepath.mdme
+	"$dm" $dmepath.mdme 2>&1 | tee result.log
 	retval=$?
+	if ! grep '0 errors, 0 warnings' result.log
+	then
+		retval=1 #hard fail, due to warnings or errors
+	fi
 else
 	if hash DreamMaker 2>/dev/null
 	then
-		DreamMaker $dmepath.mdme
+		DreamMaker $dmepath.mdme 2>&1 | tee result.log
 		retval=$?
+		if ! grep '0 errors, 0 warnings' result.log
+		then
+			retval=1 #hard fail, due to warnings or errors
+		fi
 	else
 		echo "Couldn't find the DreamMaker executable, aborting."
 		exit 3


### PR DESCRIPTION
Thereby making travis fail if a warning is emitted when building
