### PR TITLE
Increases Plasma Fist Cost to 2

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -347,7 +347,6 @@
 	desc = "Consider this more of a \"Spell Bundle\". This artifact is NOT reccomended for weaklings. An ancient scroll that will teach you the art of Plasma Fist. With it's various combos you can knock people down in the area around you, light them on fire and finally perform the PLASMA FIST that will gib your target."
 	item_path = /obj/item/weapon/plasma_fist_scroll
 	log_name = "PF"
-	cost = 1
 
 /datum/spellbook_entry/item/bloodbottle
 	name = "Bottle of Blood"

--- a/html/changelogs/Creeper Joe - Wizard Balance.yml
+++ b/html/changelogs/Creeper Joe - Wizard Balance.yml
@@ -4,4 +4,3 @@ delete-after: True
 
 changes:
   - tweak: "The Plasma Fist scroll now costs 2 instead of 1."
-  - tweak: "The Wizard's Lightning Bolt charges twice as fast."

--- a/html/changelogs/Creeper Joe - Wizard Balance.yml
+++ b/html/changelogs/Creeper Joe - Wizard Balance.yml
@@ -1,0 +1,7 @@
+author: Creeper Joe
+
+delete-after: True
+
+changes:
+  - tweak: "The Plasma Fist scroll now costs 2 instead of 1."
+  - tweak: "The Wizard's Lightning Bolt charges twice as fast."


### PR DESCRIPTION
Because right now a meager cost of 1 is way too cheap for what it brings to the table in comparison to other combat spells.
- It can be used by robeless wizards
- It has the Disintegrate ability as well as several other abilities added to it for free.
- The combos are incredibly quick to execute if you are using hotkeys. In fact, you can gib two people with a single magic missile volley before they even can get up provided they both were stunned at the same time and are in close proximity of eachother.
- None of the combos have a cooldown, which allows you to chain Plasma Fists and basically gib a lot of people in short succession

The only thing Disintegrate has going for it over Plasma Fist is the ability to insta-kill and it's ability to function on non-humans (cyborgs for example), which is already substantial. But right now, Plasma Fist is just in too good of a spot for what it brings to the table in comparison to the rest, upping the cost is a step towards balancing it out.

(Removed the cost var entirely for Plasma Fist since it defaults to 2)
