### PR TITLE
Corrected the vending machine's refill count

### DIFF
--- a/code/game/objects/items/weapons/vending_items.dm
+++ b/code/game/objects/items/weapons/vending_items.dm
@@ -69,5 +69,5 @@
 /obj/item/weapon/vending_refill/clothing
 	machine_name = "ClothesMate"
 	icon_state = "refill_clothes"
-	charges = list(29, 2, 3)// of 85 standard, 6 contraband, 7 premium
-	init_charges = list(29, 2, 3)
+	charges = list(29, 2, 2)// of 85 standard, 6 contraband, 7 premium
+	init_charges = list(29, 2, 2)

--- a/html/changelogs/JohnGinnane - correctVendingRefill.yml
+++ b/html/changelogs/JohnGinnane - correctVendingRefill.yml
@@ -1,0 +1,6 @@
+author: John Ginnane
+
+delete-after: True
+
+changes: 
+  - rscdel: "Corrected the vending machine's refill item count"


### PR DESCRIPTION
The vending machine's refill item now holds the previous value of 2 for premium items.

Fixes #2170
