### PR TITLE
Makes Cluwne unable to be acquired trough Genetics

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -322,6 +322,7 @@ var/thanks_tobba = 'icons/fonts/runescape_uf.ttf'
 
 	name = "Cluwne"
 	quality = NEGATIVE
+	dna_block = NON_SCANNABLE
 	text_gain_indication = "<span class='danger'>You feel like your brain is tearing itself apart.</span>"
 
 /datum/mutation/human/cluwne/on_acquiring(mob/living/carbon/human/owner)


### PR DESCRIPTION
Wasn't ment to be intentional. Considering this is the most debilitating mutation out there, it shouldn't be readily available to genetics. 

Not to mention that getting Cluwne on one of your monkeys basically fucks them over for life.
