### PR TITLE
Secbot can no longer be pulled when enabled

### DIFF
--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -26,6 +26,7 @@
 	radio_frequency = SEC_FREQ //Security channel
 	bot_type = SEC_BOT
 	model = "Securitron"
+	anchored = 1 //It starts out enabled doesn't it?
 
 /obj/machinery/bot/secbot/beepsky
 	name = "Officer Beep O'Sky"
@@ -61,11 +62,13 @@
 
 /obj/machinery/bot/secbot/turn_on()
 	..()
+	anchored = 1
 	icon_state = "secbot[on]"
 	updateUsrDialog()
 
 /obj/machinery/bot/secbot/turn_off()
 	..()
+	anchored = 0
 	icon_state = "secbot[on]"
 	updateUsrDialog()
 
@@ -235,7 +238,6 @@ Auto Patrol: []"},
 											"<span class='userdanger'>[src] has stunned you!</span>")
 
 					mode = BOT_PREP_ARREST
-					anchored = 1
 					target_lastloc = M.loc
 					return
 
@@ -280,7 +282,6 @@ Auto Patrol: []"},
 
 		if(BOT_ARREST)
 			if (!target)
-				anchored = 0
 				mode = BOT_IDLE
 				last_found = world.time
 				frustration = 0
@@ -295,7 +296,6 @@ Auto Patrol: []"},
 				return
 			else //Try arresting again if the target escapes.
 				mode = BOT_PREP_ARREST
-				anchored = 0
 
 		if(BOT_START_PATROL)
 			look_for_perp()

--- a/html/changelogs/Crystalwarrior160 -Securitron.yml
+++ b/html/changelogs/Crystalwarrior160 -Securitron.yml
@@ -1,0 +1,6 @@
+author: Crystalwarrior160
+
+delete-after: True
+
+changes:
+  - tweak: "You can no longer pull an active securitron around (you can pull a disabled one however)"


### PR DESCRIPTION
/title, prevents secbots from being your personal ez-arrest tools unless you actually enable them to do the job.
