### PR TITLE
Streamline inventory system a bit (Hotswapping, altclick, scooting items up with backpacks)

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -6,6 +6,10 @@
 	icon_state = "toggle"
 
 /obj/screen/human/toggle/Click()
+	var/mob/living/carbon/human/H = usr
+	if(H.inventory_hotswap())
+		return //Succesful hotswap
+
 	if(usr.hud_used.inventory_shown)
 		usr.hud_used.inventory_shown = 0
 		usr.client.screen -= usr.hud_used.other

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -380,11 +380,11 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 //the mob M is attempting to equip this item into the slot passed through as 'slot'. Return 1 if it can do this and 0 if it can't.
 //If you are making custom procs but would like to retain partial or complete functionality of this one, include a 'return ..()' to where you want this to happen.
 //Set disable_warning to 1 if you wish it to not give you outputs.
-/obj/item/proc/mob_can_equip(mob/M, slot, disable_warning = 0)
+/obj/item/proc/mob_can_equip(mob/M, slot, disable_warning = 0, return_equipped = 0)
 	if(!M)
 		return 0
 
-	return M.can_equip(src, slot, disable_warning)
+	return M.can_equip(src, slot, disable_warning, return_equipped)
 
 
 /obj/item/verb/verb_pickup()

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -18,8 +18,8 @@
 /obj/item/weapon/storage/bag
 	allow_quick_gather = 1
 	allow_quick_empty = 1
+	collection_mode = 1
 	display_contents_with_number = 1 // should work fine now
-	use_to_pickup = 1
 	slot_flags = SLOT_BELT
 
 // -----------------------------

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -257,8 +257,7 @@ var/global/biblename
 			"illogical", "very vary", "dan-approved"
 		)
 		chosenrelic.name = pick(nameprefixes) + " " + I.name
-		chosenrelic.icon = I.icon
-		chosenrelic.icon_state = I.icon_state
+		chosenrelic.icon = getFlatIcon(I)
 		qdel(src)
 	else
 		linkedbible = B

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -587,7 +587,7 @@
 	storage_slots=21
 	can_hold = list(/obj/item/weapon/light/tube, /obj/item/weapon/light/bulb)
 	max_combined_w_class = 21
-	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
+	collection_mode = 1
 
 /obj/item/weapon/storage/box/lights/bulbs/New()
 	..()

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -137,7 +137,7 @@
 	w_class = 2
 	can_hold = list(/obj/item/weapon/reagent_containers/pill,/obj/item/weapon/dice)
 	allow_quick_gather = 1
-	use_to_pickup = 1
+	collection_mode = 1
 
 /obj/item/weapon/storage/pill_bottle/MouseDrop(obj/over_object) //Quick pillbottle fix. -Agouri
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -18,11 +18,11 @@
 	var/storage_slots = 7 //The number of storage slots in this container.
 	var/obj/screen/storage/boxes = null
 	var/obj/screen/close/closer = null
-	var/use_to_pickup	//Set this to make it possible to use this item in an inverse way, so you can have the item in your hand and click items on the floor to pick them up.
-	var/display_contents_with_number	//Set this to make the storage item group contents of the same type and display them as a number.
-	var/allow_quick_empty	//Set this variable to allow the object to have the 'empty' verb, which dumps all the contents on the floor.
-	var/allow_quick_gather	//Set this variable to allow the object to have the 'toggle mode' verb, which quickly collects all items from a tile.
-	var/collection_mode = 1;  //0 = pick one at a time, 1 = pick all on tile, 2 = pick all of a type
+	var/use_to_pickup = 1	//Set this to make it possible to use this item in an inverse way, so you can have the item in your hand and click items on the floor to pick them up.
+	var/display_contents_with_number = 0	//Set this to make the storage item group contents of the same type and display them as a number.
+	var/allow_quick_empty = 0	//Set this variable to allow the object to have the 'empty' verb, which dumps all the contents on the floor.
+	var/allow_quick_gather = 0	//Set this variable to allow the object to have the 'toggle mode' verb, which quickly collects all items from a tile.
+	var/collection_mode = 0	//0 = pick one at a time, 1 = pick all on tile, 2 = pick all of a type
 	var/preposition = "in" // You put things 'in' a bag, but trays need 'on'.
 	burn_state = -1 //Shit won't burn by default.
 
@@ -62,6 +62,15 @@
 						return
 					M.put_in_l_hand(src)
 			add_fingerprint(usr)
+
+/obj/item/weapon/storage/AltClick() //Altclick is a shortcut to open the bag so you don't have to constantly drag&drop backpacks to check them w/o picking them up
+	..()
+	var/mob/M = usr
+	if(Adjacent(M))
+		orient2hud(M)
+		if(M.s_active)
+			M.s_active.close(M)
+		show_to(M)
 
 //Check if this storage can dump the items
 /obj/item/weapon/storage/proc/content_can_dump(atom/dest_object, mob/user)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -75,7 +75,7 @@
 	user.put_in_inactive_hand(O)
 	return 1
 
-/obj/item/weapon/twohanded/mob_can_equip(mob/M, slot)
+/obj/item/weapon/twohanded/mob_can_equip(mob/M, slot, disable_warning = 0, return_equipped = 0)
 	//Cannot equip wielded items.
 	if(wielded)
 		M << "<span class='warning'>Unwield the [name] first!</span>"
@@ -132,7 +132,7 @@
 /obj/item/weapon/twohanded/required/attack_self()
 	return
 
-/obj/item/weapon/twohanded/required/mob_can_equip(mob/M, slot)
+/obj/item/weapon/twohanded/required/mob_can_equip(mob/M, slot, disable_warning = 0, return_equipped = 0)
 	if(wielded)
 		M << "<span class='warning'>[src.name] is too cumbersome to carry with anything but your hands!</span>"
 		return 0

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -15,7 +15,7 @@
 
 //Returns if a certain item can be equipped to a certain slot.
 // Currently invalid for two-handed items - call obj/item/mob_can_equip() instead.
-/mob/proc/can_equip(obj/item/I, slot, disable_warning = 0)
+/mob/proc/can_equip(obj/item/I, slot, disable_warning = 0, return_equipped = 0)
 	return 0
 
 //Puts the item into your l_hand if possible and calls all necessary triggers/updates. returns 1 on success.

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -1,38 +1,69 @@
-/mob/living/carbon/human/can_equip(obj/item/I, slot, disable_warning = 0)
-	return dna.species.can_equip(I, slot, disable_warning, src)
+/mob/living/carbon/human/can_equip(obj/item/I, slot, disable_warning = 0, return_equipped = 0)
+	return dna.species.can_equip(I, slot, disable_warning, return_equipped, src)
 
 /mob/living/carbon/human/verb/quick_equip()
 	set name = "quick-equip"
 	set hidden = 1
 
-	if(ishuman(src))
-		var/mob/living/carbon/human/H = src
-		var/obj/item/I = H.get_active_hand()
-		var/obj/item/weapon/storage/S = H.get_inactive_hand()
-		if(!I)
-			H << "<span class='warning'>You are not holding anything to equip!</span>"
-			return
-		if(H.equip_to_appropriate_slot(I))
+	var/obj/item/I = get_active_hand()
+	var/obj/item/weapon/storage/S = get_inactive_hand()
+	if(!I)
+		src << "<span class='warning'>You are not holding anything to equip!</span>"
+		return
+	if(equip_to_appropriate_slot(I))
+		if(hand)
+			update_inv_l_hand()
+		else
+			update_inv_r_hand()
+	else if(s_active && s_active.can_be_inserted(I,1))	//if storage active insert there
+		s_active.handle_item_insertion(I)
+	else if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))	//see if we have box in other hand
+		S.handle_item_insertion(I)
+	else
+		S = get_item_by_slot(slot_belt)
+		if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))		//else we put in belt
+			S.handle_item_insertion(I)
+		else
+			S = get_item_by_slot(slot_back)	//else we put in backpack
+			if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))
+				S.handle_item_insertion(I)
+				playsound(loc, "rustle", 50, 1, -5)
+			else
+				src << "<span class='warning'>You are unable to equip that!</span>"
+
+//Goon-like hotswap for worn clothing
+/mob/living/carbon/human/verb/inventory_hotswap()
+	set name = "clothes-hotswap"
+	set hidden = 1
+
+	var/obj/item/I = get_active_hand()
+	if(!I)
+		return 0
+
+	//List below doesn't include pockets or backpacks because of some complications I can't be assed to figure out.
+	// Example: take box out of the backpack, put something in your pocket, use hotswap. Suddenly the box is swapped with whatever item you put in your backpack...???
+	var/list/search = list(slot_w_uniform, slot_belt, slot_wear_id, slot_wear_suit, slot_wear_mask, slot_head, slot_shoes, slot_gloves, slot_ears, slot_glasses)
+	for(var/slot in search)
+		var/check = I.mob_can_equip(src, slot, 1, 1) //disable_warning = 0; return_equipped = 0
+		if(check)
+			//This is so the items are dropped properly. Comment this snippet out if you want hotswapping to not drop the ID/belt/pockets/etc.
+			if(I == r_hand)
+				r_hand = null
+			else if(I == l_hand)
+				l_hand = null
+			//snippet end
+			if(istype(check, /obj/item))
+				var/obj/item/U = check
+				unEquip(U)
+				if(!put_in_active_hand(U))
+					U.forceMove(get_turf(src))
+			equip_to_slot(I, slot, 1) //we do equip_to_slot AFTER unEquipping existing clothing so that id's, pockets, etc. are properly emptied out
 			if(hand)
 				update_inv_l_hand()
 			else
 				update_inv_r_hand()
-		else if(s_active && s_active.can_be_inserted(I,1))	//if storage active insert there
-			s_active.handle_item_insertion(I)
-		else if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))	//see if we have box in other hand
-			S.handle_item_insertion(I)
-		else
-			S = H.get_item_by_slot(slot_belt)
-			if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))		//else we put in belt
-				S.handle_item_insertion(I)
-			else
-				S = H.get_item_by_slot(slot_back)	//else we put in backpack
-				if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))
-					S.handle_item_insertion(I)
-					playsound(src.loc, "rustle", 50, 1, -5)
-				else
-					H << "<span class='warning'>You are unable to equip that!</span>"
-
+			return 1
+	return 0
 
 /mob/living/carbon/human/proc/equip_in_one_of_slots(obj/item/I, list/slots, qdel_on_fail = 1)
 	for(var/slot in slots)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -57,6 +57,8 @@
 				unEquip(U)
 				if(!put_in_active_hand(U))
 					U.forceMove(get_turf(src))
+				if(slot == slot_w_uniform) //Changing uniforms takes 2 clicks as opposed to 1
+					return 1
 			equip_to_slot(I, slot, 1) //we do equip_to_slot AFTER unEquipping existing clothing so that id's, pockets, etc. are properly emptied out
 			if(hand)
 				update_inv_l_hand()

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -17,15 +17,15 @@
 			update_inv_r_hand()
 	else if(s_active && s_active.can_be_inserted(I,1))	//if storage active insert there
 		s_active.handle_item_insertion(I)
-	else if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))	//see if we have box in other hand
+	else if(istype(S) && S.can_be_inserted(I,1))	//see if we have box in other hand
 		S.handle_item_insertion(I)
 	else
 		S = get_item_by_slot(slot_belt)
-		if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))		//else we put in belt
+		if(istype(S) && S.can_be_inserted(I,1))		//else we put in belt
 			S.handle_item_insertion(I)
 		else
 			S = get_item_by_slot(slot_back)	//else we put in backpack
-			if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))
+			if(istype(S) && S.can_be_inserted(I,1))
 				S.handle_item_insertion(I)
 				playsound(loc, "rustle", 50, 1, -5)
 			else
@@ -57,8 +57,6 @@
 				unEquip(U)
 				if(!put_in_active_hand(U))
 					U.forceMove(get_turf(src))
-				if(slot == slot_w_uniform) //Changing uniforms takes 2 clicks as opposed to 1
-					return 1
 			equip_to_slot(I, slot, 1) //we do equip_to_slot AFTER unEquipping existing clothing so that id's, pockets, etc. are properly emptied out
 			if(hand)
 				update_inv_l_hand()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -409,7 +409,7 @@
 	// handles the equipping of species-specific gear
 	return
 
-/datum/species/proc/can_equip(obj/item/I, slot, disable_warning, mob/living/carbon/human/H)
+/datum/species/proc/can_equip(obj/item/I, slot, disable_warning, return_equipped, mob/living/carbon/human/H)
 	if(slot in no_equip)
 		if(!(type in I.species_exception))
 			return 0
@@ -420,117 +420,143 @@
 	var/num_legs = H.get_num_legs()
 	switch(slot)
 		if(slot_l_hand)
-			if(H.l_hand)
-				return 0
 			if(!L)
+				return 0
+			if(H.l_hand)
+				if(return_equipped)
+					return H.l_hand
 				return 0
 			return 1
 		if(slot_r_hand)
-			if(H.r_hand)
-				return 0
 			if(!R)
+				return 0
+			if(H.r_hand)
+				if(return_equipped)
+					return H.r_hand
 				return 0
 			return 1
 		if(slot_wear_mask)
-			if(H.wear_mask)
-				return 0
 			if( !(I.slot_flags & SLOT_MASK) )
 				return 0
 			if(!H.get_organ("head"))
 				return 0
+			if(H.wear_mask)
+				if(return_equipped)
+					return H.wear_mask
+				return 0
 			return 1
 		if(slot_back)
-			if(H.back)
-				return 0
 			if( !(I.slot_flags & SLOT_BACK) )
+				return 0
+			if(H.back)
+				if(return_equipped)
+					return H.back
 				return 0
 			return 1
 		if(slot_wear_suit)
-			if(H.wear_suit)
-				return 0
 			if( !(I.slot_flags & SLOT_OCLOTHING) )
+				return 0
+			if(H.wear_suit)
+				if(return_equipped)
+					return H.wear_suit
 				return 0
 			return 1
 		if(slot_gloves)
-			if(H.gloves)
-				return 0
 			if( !(I.slot_flags & SLOT_GLOVES) )
 				return 0
 			if(num_arms < 2)
 				return 0
+			if(H.gloves)
+				if(return_equipped)
+					return H.gloves
+				return 0
 			return 1
 		if(slot_shoes)
-			if(H.shoes)
-				return 0
 			if( !(I.slot_flags & SLOT_FEET) )
 				return 0
 			if(num_legs < 2)
 				return 0
+			if(H.shoes)
+				if(return_equipped)
+					return H.shoes
+				return 0
 			return 1
 		if(slot_belt)
-			if(H.belt)
-				return 0
 			if( !(I.slot_flags & SLOT_BELT) )
 				return
+			if(H.belt)
+				if(return_equipped)
+					return H.belt
+				return 0
 			return 1
 		if(slot_glasses)
-			if(H.glasses)
-				return 0
 			if( !(I.slot_flags & SLOT_EYES) )
 				return 0
 			if(!H.get_organ("head"))
 				return 0
+			if(H.glasses)
+				if(return_equipped)
+					return H.glasses
+				return 0
 			return 1
 		if(slot_head)
-			if(H.head)
-				return 0
 			if( !(I.slot_flags & SLOT_HEAD) )
 				return 0
 			if(!H.get_organ("head"))
 				return 0
+			if(H.head)
+				if(return_equipped)
+					return H.head
+				return 0
 			return 1
 		if(slot_ears)
-			if(H.ears)
-				return 0
 			if( !(I.slot_flags & SLOT_EARS) )
 				return 0
 			if(!H.get_organ("head"))
 				return 0
+			if(H.ears)
+				if(return_equipped)
+					return H.ears
+				return 0
 			return 1
 		if(slot_w_uniform)
-			if(H.w_uniform)
-				return 0
 			if( !(I.slot_flags & SLOT_ICLOTHING) )
+				return 0
+			if(H.w_uniform)
+				if(return_equipped)
+					return H.w_uniform
 				return 0
 			return 1
 		if(slot_wear_id)
-			if(H.wear_id)
+			if( !(I.slot_flags & SLOT_ID) )
 				return 0
 			if(!H.w_uniform && !nojumpsuit)
 				if(!disable_warning)
 					H << "<span class='warning'>You need a jumpsuit before you can attach this [I.name]!</span>"
 				return 0
-			if( !(I.slot_flags & SLOT_ID) )
+			if(H.wear_id)
+				if(return_equipped)
+					return H.wear_id
 				return 0
 			return 1
 		if(slot_l_store)
 			if(I.flags & NODROP) //Pockets aren't visible, so you can't move NODROP items into them.
 				return 0
-			if(H.l_store)
+			if(I.slot_flags & SLOT_DENYPOCKET)
 				return 0
 			if(!H.w_uniform && !nojumpsuit)
 				if(!disable_warning)
 					H << "<span class='warning'>You need a jumpsuit before you can attach this [I.name]!</span>"
 				return 0
-			if(I.slot_flags & SLOT_DENYPOCKET)
-				return
 			if( I.w_class <= 2 || (I.slot_flags & SLOT_POCKET) )
 				return 1
+			if(H.l_store)
+				if(return_equipped)
+					return H.l_store
+				return 0
 		if(slot_r_store)
 			if(I.flags & NODROP)
 				return 0
-			if(H.r_store)
-				return 0
 			if(!H.w_uniform && !nojumpsuit)
 				if(!disable_warning)
 					H << "<span class='warning'>You need a jumpsuit before you can attach this [I.name]!</span>"
@@ -539,11 +565,13 @@
 				return 0
 			if( I.w_class <= 2 || (I.slot_flags & SLOT_POCKET) )
 				return 1
+			if(H.r_store)
+				if(return_equipped)
+					return H.r_store
+				return 0
 			return 0
 		if(slot_s_store)
 			if(I.flags & NODROP)
-				return 0
-			if(H.s_store)
 				return 0
 			if(!H.wear_suit)
 				if(!disable_warning)
@@ -559,21 +587,29 @@
 				return 0
 			if( istype(I, /obj/item/device/pda) || istype(I, /obj/item/weapon/pen) || is_type_in_list(I, H.wear_suit.allowed) )
 				return 1
+			if(H.s_store)
+				if(return_equipped)
+					return H.s_store
+				return 0
 			return 0
 		if(slot_handcuffed)
-			if(H.handcuffed)
-				return 0
 			if(!istype(I, /obj/item/weapon/restraints/handcuffs))
 				return 0
 			if(num_arms < 2)
 				return 0
+			if(H.handcuffed)
+				if(return_equipped)
+					return H.handcuffed
+				return 0
 			return 1
 		if(slot_legcuffed)
-			if(H.legcuffed)
-				return 0
 			if(!istype(I, /obj/item/weapon/restraints/legcuffs))
 				return 0
 			if(num_legs < 2)
+				return 0
+			if(H.legcuffed)
+				if(return_equipped)
+					return H.legcuffed
 				return 0
 			return 1
 		if(slot_in_backpack)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -283,8 +283,9 @@ var/next_mob_id = 0
 //The list of slots by priority. equip_to_appropriate_slot() uses this list. Doesn't matter if a mob type doesn't have a slot.
 var/list/slot_equipment_priority = list( \
 		slot_back,\
-		slot_wear_id,\
 		slot_w_uniform,\
+		slot_belt,\
+		slot_wear_id,\
 		slot_wear_suit,\
 		slot_wear_mask,\
 		slot_head,\
@@ -292,7 +293,6 @@ var/list/slot_equipment_priority = list( \
 		slot_gloves,\
 		slot_ears,\
 		slot_glasses,\
-		slot_belt,\
 		slot_s_store,\
 		slot_l_store,\
 		slot_r_store\

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -435,6 +435,30 @@ var/list/slot_equipment_priority = list( \
 			update_inv_r_hand()
 	return
 
+/mob/verb/attack_inactive_hand()
+	set name = "Attack Inactive Hand"
+	set category = "Object"
+	set src = usr
+
+	if(istype(loc,/obj/mecha)) return
+
+	var/obj/item/W
+	if(hand)
+		W = l_hand
+	else
+		W = r_hand
+
+	var/obj/item/I = get_inactive_hand()
+	if(istype(I))
+		if (istype(W))
+			var/resolved = I.attackby(W,src)
+			if(!resolved && I && W)
+				W.afterattack(I,src,1) // 1 indicates adjacency
+		else
+			UnarmedAttack(I)
+		update_inv_l_hand()
+		update_inv_r_hand()
+
 /*
 /mob/verb/dump_source()
 

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -7,7 +7,6 @@
 	w_class = 5
 	can_hold = list(/obj/item/weapon/stock_parts)
 	storage_slots = 50
-	use_to_pickup = 1
 	allow_quick_gather = 1
 	allow_quick_empty = 1
 	collection_mode = 1

--- a/html/changelogs/Crystalwarrior160 - YayStreamline.yml
+++ b/html/changelogs/Crystalwarrior160 - YayStreamline.yml
@@ -8,3 +8,4 @@ changes:
   - tweak: "  You can now click the toggle-clothes-UI thing in the bottom left corner with clothing in-hand to quick switch that clothing for yourself! (quick-switching uniforms will still empty out your pockets, etc.)"
   - tweak: "  You can now click with most storage items in-hand to store target item in it"
   - tweak: "  You can now alt-click storage items to check their contents without picking it up (makes drag&drop more useful for actual dumping so there's less accidental emptying out)"
+  - tweak: "  Added a new 'Attack Inactive Hand' mob verb and a keybind! Press C or Ctrl+C to 'click' something in your inactive hand with your active hand. You can also 'swap hands' for items with this, essentially!"

--- a/html/changelogs/Crystalwarrior160 - YayStreamline.yml
+++ b/html/changelogs/Crystalwarrior160 - YayStreamline.yml
@@ -1,0 +1,10 @@
+author: Crystalwarrior160
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed relics not working properly on limbs. Relics now properly do a snapshot of the item they're copying, too."
+  - tweak: "Streamlined inventory system a bit - "
+  - tweak: "  You can now click the toggle-clothes-UI thing in the bottom left corner with clothing in-hand to quick switch that clothing for yourself! (quick-switching uniforms will still empty out your pockets, etc.)"
+  - tweak: "  You can now click with most storage items in-hand to store target item in it"
+  - tweak: "  You can now alt-click storage items to check their contents without picking it up (makes drag&drop more useful for actual dumping so there's less accidental emptying out)"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -180,6 +180,14 @@ macro "borghotkeymode"
 		command = ".northeast"
 		is-disabled = false
 	elem 
+		name = "C"
+		command = "Attack-Inactive-Hand"
+		is-disabled = false
+	elem 
+		name = "CTRL+C"
+		command = "Attack-Inactive-Hand"
+		is-disabled = false
+	elem 
 		name = "Y"
 		command = "Activate-Held-Object"
 		is-disabled = false
@@ -702,6 +710,14 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+X"
 		command = ".northeast"
+		is-disabled = false
+	elem 
+		name = "C"
+		command = "Attack-Inactive-Hand"
+		is-disabled = false
+	elem 
+		name = "CTRL+C"
+		command = "Attack-Inactive-Hand"
 		is-disabled = false
 	elem 
 		name = "Y"


### PR DESCRIPTION
ayy
     - bugfix: "Fixed relics not working properly on limbs. Relics now properly do a snapshot of the item they're copying, too."
     - tweak: "Streamlined inventory system a bit - "
     - tweak: "  You can now click the toggle-clothes-UI thing in the bottom left corner with clothing in-hand to quick switch that clothing for yourself! (quick-switching uniforms will still empty out your pockets, etc.)"
     - tweak: "  You can now click with most storage items in-hand to store target item in it"
     - tweak: "  You can now alt-click storage items to check their contents without picking it up (makes drag&drop more useful for actual dumping so there's less accidental emptying out)"
    - tweak: "  Added a new 'Attack Inactive Hand' mob verb and a keybind! Press C or Ctrl+C to 'click' something in your inactive hand with your active hand. You can also 'swap hands' for items with this, essentially!"
