### PR TITLE
Updates all Admin names ontop of the Changelog

### DIFF
--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -37,10 +37,10 @@
 			<font size='2'><b>Host:</b> Admiral_Hippie <br></font>
 			<font size='2'><b>Head Admins:</b> Nebyab, Mcbawbaggings, Teamstab</font><br>
 			<font size='2'><b>Head Coder:</b> Nalar <br></font>
-			<font size='2'><b>Game Masters:</b> Looping, Dudeinyourbackyard, Nalar, Calibraptor, Bartels, Brawzki<br></font>
-			<font size='2'><b>Game Admins:</b>DrunkenFlyingDemoman, Lord_Kruor, Carbonhell, Speakercity, Zadeon, Yobob, Kokojo, Chaznoodles, Teamstab, Hutchen, Nexendia, Gandalf2k15, Snake2512, McHatters, Badmex, Spacedong, Solidfury7, Wallaceshark<br></font>
-			<font size='2'><b>Coding/Spriting/Mapping Team:</b> 1Block, Carbonhell, JayGriff, Memendia, Mocheeze, Nalar, Nienhaus, Tdcoolguy300, Oprayx73, Redswandir, Pyko <br></font>
-			<font size='2'><b>Mentors:</b> JamesButts, Cafaling, Cairo283, WitheredGryphon, rg4ordr, death1, zachorem, zomboing, 8000roxas1234, lowresolution, oprayx73, danke, tentacletherapist, dungeonbones, nexendia, Rain7x, blobbernaut, themostcleverbot, Vievioora, derpthestewpidgoat, voltz6787, neoplague, 2dollarbill, wyatt321, Kyle90210, typhx, Skeleton9, Kainoa, Fluxcapacitor1337, Francisyorkmorgan, Finefire984, caxxo<br></font>
+			<font size='2'><b>Game Masters:</b> Looping, Dudeinyourbackyard, Calibraptor, Bartels, Brawzki<br></font>
+			<font size='2'><b>Game Admins:</b>Dan Hibiki, DrunkenFlyingDemoman, Lord_Kruor, Carbonhell, Speakercity, Zadeon, Yobob, Kokojo, Chaznoodles, Hutchen, Nexendia, Gandalf2k15, Snake2512, McHatters, Spacedong, Solidfury7, Wallaceshark, Lawoggamer<br></font>
+			<font size='2'><b>Coding/Spriting/Mapping Team:</b> Pyko, Johnfg, Whitefox08, Scooterkid, Tdcoolguy300 <br></font>
+			<font size='2'><b>Mentors:</b> JamesButts, Cafaling, Cairo283, WitheredGryphon, rg4ordr, death1, zachorem, zomboing, 8000roxas1234, lowresolution, oprayx73, danke, tentacletherapist, dungeonbones, Rain7x, blobbernaut, themostcleverbot, Vievioora, derpthestewpidgoat, voltz6787, neoplague, 2dollarbill, wyatt321, Kyle90210, typhx, Skeleton9, Kainoa, Fluxcapacitor1337, Francisyorkmorgan, Finefire984, caxxo<br></font>
 		</td>
 	</tr>
 </table>

--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -35,12 +35,12 @@
 	<tr>
 		<td valign='top'>
 			<font size='2'><b>Host:</b> Admiral_Hippie <br></font>
-			<font size='2'><b>Head Admins:</b> Nebyab, Nokington</font><br>
+			<font size='2'><b>Head Admins:</b> Nebyab, Mcbawbaggings, Teamstab</font><br>
 			<font size='2'><b>Head Coder:</b> Nalar <br></font>
-			<font size='2'><b>Game Masters:</b> Looping, Dudeinyourbackyard, Nalar, Calibraptor, Zyzarda, Bartels, Limed00d, Brawzki<br></font>
-			<font size='2'><b>Game Admins:</b>CobyB, DrunkenFlyingDemoman, Lord_Kruor, Markoboy, doobiedoo23, Carbonhell, Speakercity, Zadeon, Yobob, Mcbawbaggings, Kokojo, Chaznoodles, Teamstab, Hutchen<br></font>
+			<font size='2'><b>Game Masters:</b> Looping, Dudeinyourbackyard, Nalar, Calibraptor, Bartels, Brawzki<br></font>
+			<font size='2'><b>Game Admins:</b>DrunkenFlyingDemoman, Lord_Kruor, Carbonhell, Speakercity, Zadeon, Yobob, Kokojo, Chaznoodles, Teamstab, Hutchen, Nexendia, Gandalf2k15, Snake2512, McHatters, Badmex, Spacedong, Solidfury7, Wallaceshark<br></font>
 			<font size='2'><b>Coding/Spriting/Mapping Team:</b> 1Block, Carbonhell, JayGriff, Memendia, Mocheeze, Nalar, Nienhaus, Tdcoolguy300, Oprayx73, Redswandir, Pyko <br></font>
-			<font size='2'><b>Mentors:</b> McHatters, JamesButts, Cafaling, Cairo283, WitheredGryphon, rg4ordr, death1, SolidFury7, zachorem, zomboing, 8000roxas1234, lowresolution, oprayx73, danke, tentacletherapist, dungeonbones, nexendia, Rain7x, blobbernaut, themostcleverbot, Vievioora, derpthestewpidgoat, voltz6787, neoplague, 2dollarbill, wyatt321, Kyle90210, typhx, Skeleton9, Kainoa, Fluxcapacitor1337, Francisyorkmorgan, Finefire984, caxxo<br></font>
+			<font size='2'><b>Mentors:</b> JamesButts, Cafaling, Cairo283, WitheredGryphon, rg4ordr, death1, zachorem, zomboing, 8000roxas1234, lowresolution, oprayx73, danke, tentacletherapist, dungeonbones, nexendia, Rain7x, blobbernaut, themostcleverbot, Vievioora, derpthestewpidgoat, voltz6787, neoplague, 2dollarbill, wyatt321, Kyle90210, typhx, Skeleton9, Kainoa, Fluxcapacitor1337, Francisyorkmorgan, Finefire984, caxxo<br></font>
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
Didn't touch the mentor names (aside from taking out the names of those that became admins), I'll do that another time.
