### PR TITLE
Tweaked shield values a bit + disablers now count as 'laser' for armors/shields

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -66,7 +66,7 @@
 	materials = list(MAT_GLASS=7500, MAT_METAL=1000)
 	origin_tech = "materials=2"
 	slowdown_deployed = 2
-	block_chance_deployed = list(melee = 70, bullet = 60, laser = 40, energy = 30) //Reason why melee value is so high is because the shield applies sizable slowdown to you now. It should be viable to give you an edge in melee combat mostly.
+	block_chance_deployed = list(melee = 70, bullet = 60, laser = 0, energy = 70) //This is good against melee, bullets and energy (disablers & electrodes) but absolutely garbage against lasers
 	var/cooldown = 0
 
 /obj/item/weapon/shield/deployable/riot/attack_self(mob/living/user)
@@ -142,7 +142,7 @@
 	materials = list(MAT_GLASS=7500, MAT_METAL=1000)
 	origin_tech = "materials=2"
 	force_deployed = 8
-	block_chance_deployed = list(melee = 50, bullet = 30, laser = 20, energy = 20)
+	block_chance_deployed = list(melee = 50, bullet = 60, laser = 0, energy = 50)
 
 /obj/item/weapon/shield/deployable/tele/hit_reaction(mob/owner, attack_text, final_block_chance)
 	if(active)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -39,7 +39,7 @@
 	icon_state = "omnilaser"
 	damage = 36
 	damage_type = STAMINA
-	flag = "energy"
+	flag = "laser" //Armors and Shields should assume disablers are lasers - makes more sense that way.
 	hitsound = 'sound/weapons/tap.ogg'
 	eyeblur = 0
 

--- a/html/changelogs/Crystalwarrior160 - ShieldBuffNerfSomething.yml
+++ b/html/changelogs/Crystalwarrior160 - ShieldBuffNerfSomething.yml
@@ -1,0 +1,9 @@
+author: Crystalwarrior160
+
+delete-after: True
+
+changes:
+  - tweak: "Disablers now count as 'laser' instead of 'energy' for armor and shields"
+  - tweak: "Changed shield values a bit:"
+  - tweak: "  Riot Shield - 70% melee, 60% bullet, 0% laser, 70% energy"
+  - tweak: "  Telescopic Shield - 50% melee, 60% bullet, 0% laser, 50% energy"


### PR DESCRIPTION
```
 - tweak: "Disablers now count as 'laser' instead of 'energy' for armor and shields"
 - tweak: "Changed shield values a bit:"
 - tweak: "  Riot Shield - 70% melee, 60% bullet, 0% laser, 70% energy"
 - tweak: "  Telescopic Shield - 50% melee, 60% bullet, 0% laser, 50% energy"
```

Reason for both is to make riot shields and telescopic shields super viable against greytide, tasers and nuke ops scum, but non-viable if someone is wielding a laser gun or is smart enough to actually use disablers. Keep in mind that you're still able to fight back and you're still able to use tasers, soo it's much of a buff-compromise than a nerf.

Telescopic Shield is a well-rounded decent protection, resembling how shields were prior to update, though now lasers and disablers will be a counter against both types of shields (for one, it makes sense - they're glass/transparent plastic, and for two it's a good compromise for their stun-blocking potential + melee)

Riot Shields now have a MUCH bigger chance to block stuns, which makes a lot more sense given that riot shields now slow you down.
