### PR TITLE
Fixes decapitation/debraining forcing ghosts back into old body

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -59,9 +59,10 @@
 
 	var/datum/vampire/vampire //The vampire data stored in the mind
 
+	var/ghost = 0 // Used to identify if a mind is currently ghosting
+
 /datum/mind/New(var/key)
 	src.key = key
-
 
 /datum/mind/proc/transfer_to(mob/living/new_character)
 	/*if(!istype(new_character))
@@ -89,7 +90,7 @@
 	transfer_antag_huds(hud_to_transfer)					//inherit the antag HUD
 	transfer_actions(new_character)
 
-	if(active)
+	if(active && !ghost)
 		new_character.key = key		//now transfer the key to link the client to our new body
 
 /datum/mind/proc/store_memory(new_text)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -173,9 +173,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	mind.current.key = key
 
 	var/mob/living/L = mind.current
-	L << "[L.name]: [L.mind.ghost]"
 	L.mind.ghost = 0
-	L << "[L.name]: [L.mind.ghost]"
 
 	return 1
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -50,6 +50,7 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 				name = random_unique_name(gender)
 
 		mind = body.mind	//we don't transfer the mind but we keep a reference to it.
+		mind.ghost = 1
 
 	if(!T)	T = pick(latejoin)			//Safety in case we cannot find the body's position
 	loc = T
@@ -86,6 +87,10 @@ Works together with spawning an observer, noted above.
 			var/mob/dead/observer/ghost = new(src)	//Transfer safety to observer spawning proc.
 			ghost.can_reenter_corpse = can_reenter_corpse
 			ghost.key = key
+
+			if(mind)
+				mind.ghost = 1
+
 			return ghost
 
 /*
@@ -110,7 +115,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(response != "Ghost")	return	//didn't want to ghost after-all
 		ghostize(0)						//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 	return
-
 
 /mob/dead/observer/Move(NewLoc, direct)
 	if(NewLoc)
@@ -155,7 +159,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/verb/reenter_corpse()
 	set category = "Ghost"
 	set name = "Re-enter Corpse"
-	if(!client)	return
+	if(!client)	
+		return
 	if(!(mind && mind.current))
 		src << "<span class='warning'>You have no body.</span>"
 		return
@@ -166,6 +171,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		usr << "<span class='warning'>Another consciousness is in your body...It is resisting you.</span>"
 		return
 	mind.current.key = key
+
+	var/mob/living/L = mind.current
+	L << "[L.name]: [L.mind.ghost]"
+	L.mind.ghost = 0
+	L << "[L.name]: [L.mind.ghost]"
+
 	return 1
 
 /mob/dead/observer/proc/notify_cloning(var/message, var/sound)
@@ -355,6 +366,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return 0
 
 	target.key = key
+	mind.ghost = 0
 	return 1
 
 

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -49,7 +49,6 @@
 		if(brainmob && brainmob.client)
 			brainmob.client.screen.len = null //clear the hud
 
-
 /obj/item/organ/internal/brain/proc/transfer_identity(mob/living/L)
 	name = "[L.name]'s brain"
 	brainmob = new(src)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -79,8 +79,6 @@
 //Looking for brains?
 //Try code/modules/mob/living/carbon/brain/brain_item.dm
 
-
-
 /obj/item/organ/internal/heart
 	name = "heart"
 	icon_state = "heart-on"


### PR DESCRIPTION
Fixes #2289
Fixes #2140

I've added a new variable to the mind datum called "ghost". This is set to 1 when you ghost (or aghost) and then reset to 0 if you reenter your body.

It's checked when your mind is being transferred so that if this is one your key isn't transferred also. Did local testing with new humans being offered to ghosts and the was-ghost player remained inside the new human after decapitating his old body, as well as debraining via surgery.
