### PR TITLE
Fix console comms spam

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -569,8 +569,9 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 
 /obj/machinery/computer/communications/proc/make_announcement(mob/living/user, is_silicon)
 	var/input = stripped_input(user, "Please choose a message to announce to the station crew.", "What?")
-	if(!input || !user.canUseTopic(src))
+	if(!input || !user.canUseTopic(src) || (message_cooldown && !is_silicon) || (ai_message_cooldown && is_silicon))
 		return
+
 	if(is_silicon)
 		minor_announce(input)
 		ai_message_cooldown = 1
@@ -581,10 +582,9 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 		message_cooldown = 1
 		spawn(600)//One minute cooldown
 			message_cooldown = 0
+
 	log_say("[key_name(user)] has made a priority announcement: [input]")
 	message_admins("[key_name_admin(user)] has made a priority announcement.")
-
-
 
 /obj/machinery/computer/communications/proc/post_status(command, data1, data2)
 

--- a/html/changelogs/JohnGinnane - fixCommsConsoleSpam.yml
+++ b/html/changelogs/JohnGinnane - fixCommsConsoleSpam.yml
@@ -1,0 +1,6 @@
+author: John Ginnane
+
+delete-after: True
+
+changes: 
+  - rscadd: "Fixed users being able to spam priority announcements."

--- a/html/changelogs/JohnGinnane - fixCommsConsoleSpam.yml
+++ b/html/changelogs/JohnGinnane - fixCommsConsoleSpam.yml
@@ -3,4 +3,4 @@ author: John Ginnane
 delete-after: True
 
 changes: 
-  - rscadd: "Fixed users being able to spam priority announcements."
+  - bugfix: "Fixed users being able to spam priority announcements."


### PR DESCRIPTION
Added more conditions to the make_announcement proc so it will return if either cooldown is active.

Fixes #2317
Fixes #2318
