### PR TITLE
Fix ghosting

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -59,6 +59,8 @@
 
 	var/datum/vampire/vampire //The vampire data stored in the mind
 
+	var/ghost = FALSE // This is used to determine if the mind is ghosting or not
+
 /datum/mind/New(var/key)
 	src.key = key
 
@@ -89,7 +91,7 @@
 	transfer_antag_huds(hud_to_transfer)					//inherit the antag HUD
 	transfer_actions(new_character)
 
-	if(active)
+	if(active && !ghost)
 		new_character.key = key		//now transfer the key to link the client to our new body
 
 /datum/mind/proc/store_memory(new_text)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -49,6 +49,7 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 			else
 				name = random_unique_name(gender)
 
+		body.mind.ghost = TRUE
 		mind = body.mind	//we don't transfer the mind but we keep a reference to it.
 
 	if(!T)	T = pick(latejoin)			//Safety in case we cannot find the body's position
@@ -98,19 +99,32 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/mob/living/carbon/H = src
 
+	var/confirm_ghost = FALSE
+
 	if(stat != DEAD)
 		succumb()
+
 	if(stat == DEAD)
 		ghostize(1)
-	if(istype(H) && (H.dna.check_mutation(CLUWNEMUT)) & !(stat == DEAD))
-		H << "Cluwnes cannot ghost until they've died! Find a natural means of death!"
-		return
-	else
-		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
-		if(response != "Ghost")	return	//didn't want to ghost after-all
-		ghostize(0)						//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
-	return
 
+	if(istype(H) && H.dna)
+		if(H.dna.check_mutation(CLUWNEMUT) && stat != DEAD)
+			H << "Cluwnes cannot ghost until they've died! Find a natural means of death!"
+			return
+		else
+			confirm_ghost = TRUE
+	else
+		confirm_ghost = TRUE
+
+	if(confirm_ghost)
+		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
+
+		if(response != "Ghost")	
+			return	//didn't want to ghost after-all
+
+		ghostize(0)						//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
+
+	return
 
 /mob/dead/observer/Move(NewLoc, direct)
 	if(NewLoc)
@@ -155,17 +169,27 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/verb/reenter_corpse()
 	set category = "Ghost"
 	set name = "Re-enter Corpse"
-	if(!client)	return
+
+	if(!client)	
+		return
+
 	if(!(mind && mind.current))
 		src << "<span class='warning'>You have no body.</span>"
 		return
+
 	if(!can_reenter_corpse)
 		src << "<span class='warning'>You cannot re-enter your body.</span>"
 		return
+
 	if(mind.current.key && copytext(mind.current.key,1,2)!="@")	//makes sure we don't accidentally kick any clients
 		usr << "<span class='warning'>Another consciousness is in your body...It is resisting you.</span>"
 		return
+
 	mind.current.key = key
+
+	var/mob/living/L = mind.current
+	L.mind.ghost = FALSE
+
 	return 1
 
 /mob/dead/observer/proc/notify_cloning(var/message, var/sound)
@@ -355,6 +379,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return 0
 
 	target.key = key
+	mind.ghost = FALSE
+	
 	return 1
 
 

--- a/html/changelogs/JohnGinnane - fixGhosting.yml
+++ b/html/changelogs/JohnGinnane - fixGhosting.yml
@@ -1,0 +1,6 @@
+author: John Ginnane
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed players sometimes being forced out of new bodies and into their old one if they're debrained or decapitated."


### PR DESCRIPTION
Fixes #2289
Fixes #2140
Fixes #2273
Fixes #2283 (possibly)

I've added a new variable to the mind datum called "ghost". This is set to 1 when you ghost (or aghost) and then reset to 0 if you reenter your body or possess another mob/living.

It's checked when your mind is being transferred so that if this is true your key isn't transferred. Did local testing with new humans being offered to ghosts and the was-ghost player remained inside the new human after decapitating his old body, as well as debraining via surgery.
