### PR TITLE
Fixes {#1930} - Zombie Disease is now properly deleted on failed infection

### DIFF
--- a/code/datums/diseases/zombie.dm
+++ b/code/datums/diseases/zombie.dm
@@ -102,5 +102,5 @@ var/list/zombie_cure = list()
 			H.Zombify()
 			cure()
 			return
-		if(prob(stage_prob)) //Faster transformation that way
-			stage = min(stage+1, max_stages)
+		if(stage_prob <= initial(stage_prob))
+			stage_prob *= 2

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -36,6 +36,8 @@
 
 	var/list/z_armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
+	var/can_possess = 1 //Whether or not this zombie can be possessed by ghosts
+
 	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/zombie = 3)
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	see_in_dark = 5
@@ -55,17 +57,20 @@
 	return P.on_hit(src, armor, def_zone)
 
 /mob/living/simple_animal/hostile/zombie/New(turf/loc, provided_key)
-	if(!provided_key || !client)
+	if(can_possess && (!provided_key || !client))
 		notify_ghosts("A new NPC zombie has risen in [get_area(src)]! <a href=?src=\ref[src];ghostjoin=1>(Click to take control)</a>")
 	..()
 
 /mob/living/simple_animal/hostile/zombie/Topic(href, href_list)
-	if(href_list["ghostjoin"])
+	if(href_list["ghostjoin"] && can_possess)
 		var/mob/dead/observer/ghost = usr
 		if(istype(ghost))
 			attack_ghost(ghost)
 
 /mob/living/simple_animal/hostile/zombie/attack_ghost(mob/user)
+	if(!can_possess)
+		user << "This zombie cannot be possessed!"
+		return
 	if(ckey && client)
 		user << "The zombie is already controlled by a player."
 		return
@@ -117,6 +122,7 @@
 						src << "<span class='userdanger'>[H] is already infected!</span>"
 					else
 						src << "<span class='userdanger'>You couldn't quite bite into [H].</span>"
+					qdel(Z) //Delete the disease due to contract failure. Otherwise controller might shit itself.
 		else if (L.stat) //Not human, feast!
 			playsound(loc, 'sound/weapons/slice.ogg', 50, 1, -1)
 			visible_message("<span class='danger'>[src] begins consuming [L]!</span>",\
@@ -125,7 +131,7 @@
 				visible_message("<span class='danger'>[src] tears [L] to pieces!</span>",\
 								"<span class='userdanger'>You feast on [L], restoring your health!</span>")
 				L.gib()
-				src.revive()
+				revive()
 			return
 
 	target.attack_animal(src)

--- a/html/changelogs/Crystalwarrior160 - zombie.yml
+++ b/html/changelogs/Crystalwarrior160 - zombie.yml
@@ -1,0 +1,6 @@
+author: Crystalwarrior160
+
+delete-after: True
+
+changes:
+  - bugfix: "Possibly fixed zombies causing server lag"


### PR DESCRIPTION
Also, this adds a new "can_possess" variable to zombies for mappers so you can have non-possessable gateway zombies. Woo!
