### PR TITLE
Fix missing limbs being able to hold items

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -329,3 +329,41 @@
 		return 0
 
 	return O.equip(src, visualsOnly)
+
+/mob/living/carbon/human/proc/handle_inventory()
+	var/missing_hands = 0
+
+	if(!get_organ("l_arm"))
+		drop_l_hand()
+		missing_hands = missing_hands + 1
+
+	if(!get_organ("r_arm"))
+		drop_r_hand()
+		missing_hands = missing_hands + 1
+
+	if(missing_hands)
+		unEquip(gloves)
+
+		if(handcuffed)
+			handcuffed.loc = loc
+			handcuffed.dropped(src)
+			handcuffed = null
+
+			if(buckled && buckled.buckle_requires_restraints)
+				buckled.unbuckle_mob()
+			update_inv_handcuffed()
+
+	if(!get_organ("head"))
+		for(var/obj/item/I in list(glasses, ears, wear_mask, head))
+			unEquip(I)
+	
+	if(!get_organ("l_leg") || !get_organ("r_leg"))
+		unEquip(shoes)
+
+		if(legcuffed)
+			legcuffed.loc = loc
+			legcuffed.dropped()
+			legcuffed = null
+			update_inv_legcuffed()
+
+	return 1

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -62,6 +62,7 @@
 	if(is_vampire(src))
 		handle_vampirism()
 
+	handle_inventory()
 
 /mob/living/carbon/human/calculate_affecting_pressure(pressure)
 	if((wear_suit && (wear_suit.flags & STOPSPRESSUREDMAGE)) && (head && (head.flags & STOPSPRESSUREDMAGE)))

--- a/html/changelogs/JohnGinnane - fixMissingLimbsHoldingItems.yml
+++ b/html/changelogs/JohnGinnane - fixMissingLimbsHoldingItems.yml
@@ -1,0 +1,6 @@
+author: John Ginnane
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed humans being able to sometimes hold items with hands they don't hate."

--- a/html/changelogs/JohnGinnane - fixMissingLimbsHoldingItems.yml
+++ b/html/changelogs/JohnGinnane - fixMissingLimbsHoldingItems.yml
@@ -3,4 +3,4 @@ author: John Ginnane
 delete-after: True
 
 changes: 
-  - bugfix: "Fixed humans being able to sometimes hold items with hands they don't hate."
+  - bugfix: "Fixed humans being able to sometimes hold items with hands they don't have."


### PR DESCRIPTION
Added a new proc, "handle_inventory" which is called within a human's
"life". This will do a check for limbs that are missing and basically
drop anything that can't actually hold/wear.

Fixes #2262
