### PR TITLE
Fix bent pipes becoming unbent

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -254,9 +254,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	if (loc == user)
 		if(!user.unEquip(src))
 			return
-
-	dir = SOUTH //Reset the item direction to SOUTH so directional items appear proper in-hand
-
+	
 	pickup(user)
 	add_fingerprint(user)
 	if(!user.put_in_active_hand(src))

--- a/html/changelogs/JohnGinnane - fixBentPipesPickup.yml
+++ b/html/changelogs/JohnGinnane - fixBentPipesPickup.yml
@@ -1,0 +1,6 @@
+author: John Ginnane
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed bent pipe's direction being reset when you pick them up."


### PR DESCRIPTION
Removed setting dir = SOUTH from item/attackby(). Not sure why it was put there. Need to talk to Crystal.

Cause: https://github.com/HippieStationCode/HippieStation13/commit/569438d98fe30e90711c1f4e0ad356dd784fc5d4#diff-ac3b89e91ad083b3cb3fdb669006158c

Fixes #2251
