### PR TITLE
Fix cane gun reskin

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -11,6 +11,8 @@
 	var/mag_load_sound = 'sound/effects/wep_magazines/handgun_generic_load.ogg'
 	var/mag_unload_sound = 'sound/effects/wep_magazines/handgun_generic_unload.ogg'
 	var/chamber_sound = 'sound/effects/wep_magazines/generic_chamber.ogg'
+	
+	var/can_sawn = FALSE
 
 /obj/item/weapon/gun/projectile/New()
 	..()

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -79,6 +79,7 @@
 
 /obj/item/weapon/gun/projectile/shotgun/riot/attackby(obj/item/A, mob/user, params)
 	..()
+
 	if(istype(A, /obj/item/weapon/circular_saw) || istype(A, /obj/item/weapon/gun/energy/plasmacutter))
 		sawoff(user)
 	if(istype(A, /obj/item/weapon/melee/energy))
@@ -103,6 +104,7 @@
 	can_knife = 1
 	knife_x_offset = 17
 	knife_y_offset = 13
+	can_sawn = TRUE
 
 /obj/item/weapon/gun/projectile/shotgun/boltaction/pump(mob/M)
 	if(bolt_open)
@@ -154,6 +156,7 @@
 	sawn_desc = "Omar's coming!"
 	unique_rename = 1
 	unique_reskin = 1
+	can_sawn = TRUE
 
 /obj/item/weapon/gun/projectile/revolver/doublebarrel/New()
 	..()
@@ -210,7 +213,7 @@
 	mag_load_sound = 'sound/effects/wep_magazines/rifle_load.ogg'
 	mag_unload_sound = 'sound/effects/wep_magazines/rifle_bolt_back.ogg'
 	chamber_sound = null
-
+	can_sawn = TRUE
 
 /obj/item/weapon/gun/projectile/revolver/doublebarrel/improvised/attackby(obj/item/A, mob/user, params)
 	..()
@@ -234,7 +237,6 @@
 	icon_state = "cane"
 	item_state = "stick"
 	icon = 'icons/obj/weapons.dmi'
-	sawn_state = SAWN_OFF
 	w_class = 2
 	force = 10
 	can_unsuppress = 0
@@ -244,6 +246,7 @@
 	fire_sound = 'sound/weapons/shotgun.ogg'
 	sawn_desc = "I'm sorry, but why did you saw your cane in the first place?"
 	unique_reskin = 1
+	reskinned = 0
 	mag_load_sound = null
 	mag_unload_sound = null
 	chamber_sound = null
@@ -252,7 +255,7 @@
 	suppressed = 1
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
-	var/list/cane_choices = list()
+	can_sawn = FALSE
 
 /obj/item/weapon/gun/projectile/revolver/doublebarrel/improvised/cane/update_slowdown(mob/user)
 	var/mob/living/carbon/human/H = user
@@ -281,32 +284,13 @@
 
 /obj/item/weapon/gun/projectile/revolver/doublebarrel/improvised/cane/New()
 	..()
-	for(var/U in typesof(/obj/item/weapon/cane))
-		var/obj/item/weapon/cane/V = new U
-		src.cane_choices += V
+	
+	options = list()
+	options["Pimp Stick"] = "pimpstick"
+	options["Cane"] = "cane"
+	options["Cancel"] = null
+
 	return
-/obj/item/weapon/gun/projectile/revolver/doublebarrel/improvised/cane/verb/Change()
-
-	set src in usr
-
-	var/obj/item/weapon/cane/A
-	A = input("Select Design to change it to", "BOOYEA", A) in cane_choices
-	if(!A)
-		return
-
-	if(usr.stat != CONSCIOUS)
-		return
-
-	desc = null
-
-	desc = A.desc
-	name = A.name
-	attack_verb = A.attack_verb
-	icon_state = A.icon_state
-	item_state = A.item_state
-	usr.update_inv_l_hand()
-	usr.update_inv_r_hand()
-
 
 // Sawing guns related procs //
 
@@ -326,6 +310,10 @@
 /obj/item/weapon/gun/projectile/proc/sawoff(mob/user)
 	if(sawn_state == SAWN_OFF)
 		user << "<span class='warning'>\The [src] is already shortened!</span>"
+		return
+
+	if(!can_sawn)
+		user << "<span class='warning'>You're unable to shorten this weapon!</span>"
 		return
 
 	if(sawn_state == SAWN_SAWING)
@@ -493,6 +481,7 @@
 	origin_tech = "combat=4;materials=2"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/triple
 	fire_sound = 'sound/weapons/shotgun.ogg'
+	can_sawn = FALSE
 
 // Lever Action //
 
@@ -505,7 +494,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/lever
 	fire_sound = 'sound/weapons/shotgun.ogg'
 	w_class = 3
-
+	can_sawn = FALSE
 
 // breechloader
 
@@ -526,3 +515,4 @@
 	spread = 7
 	unique_rename = 0
 	unique_reskin = 0
+	can_sawn = FALSE

--- a/html/changelogs/JohnGinnane - fixCanegun.yml
+++ b/html/changelogs/JohnGinnane - fixCanegun.yml
@@ -1,0 +1,7 @@
+author: John Ginnane
+
+delete-after: True
+
+changes: 
+  - bugfix: "Reworked the canegun to allow you to only reskin it once, so it's now consistent with other guns."
+  - bugfix: "Can no longer make the canegun sawn-off."


### PR DESCRIPTION
Reworked how the skin works for cangun. You can only reskin it once so it's consistent with other guns (e.g. double barrel shotgun). You can no longer saw off the cane gun, using the the new can_sawn bool variable.

Fixes #2294
