### PR TITLE
Fixed ghosting (again)

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -59,6 +59,8 @@
 
 	var/datum/vampire/vampire //The vampire data stored in the mind
 
+	var/ghost = FALSE // This is used to determine if the mind if ghosting or not
+
 /datum/mind/New(var/key)
 	src.key = key
 
@@ -89,7 +91,7 @@
 	transfer_antag_huds(hud_to_transfer)					//inherit the antag HUD
 	transfer_actions(new_character)
 
-	if(active)
+	if(active && !ghost)
 		new_character.key = key		//now transfer the key to link the client to our new body
 
 /datum/mind/proc/store_memory(new_text)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -123,7 +123,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(response != "Ghost")	
 			return	//didn't want to ghost after-all
 
-			ghostize(0)	//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
+		ghostize(0)	//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 
 	return
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -123,7 +123,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(response != "Ghost")	
 			return	//didn't want to ghost after-all
 
-		ghostize(0)	//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
+			ghostize(0)	//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 
 	return
 

--- a/html/changelogs/JohnGinnane - fixGhostingAgain.yml
+++ b/html/changelogs/JohnGinnane - fixGhostingAgain.yml
@@ -1,0 +1,6 @@
+author: John Ginnane
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed players sometimes being forced out of new bodies and into their old one if they're debrained or decapitated."


### PR DESCRIPTION
Resubmitting https://github.com/HippieStationCode/HippieStation13/pull/2344

I've added a new variable to the mind datum called "ghost". This is set to 1 when you ghost (or aghost) and then reset to 0 if you reenter your body or possess another mob/living.

It's checked when your mind is being transferred so that if this is true your key isn't transferred. Did local testing with new humans being offered to ghosts and the was-ghost player remained inside the new human after decapitating his old body, as well as debraining via surgery.

Fixes #2289
Fixes #2140
Fixes #2273
Fixes #2283 (possibly)
