### PR TITLE
Fix console comms spam (again)

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -569,8 +569,9 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 
 /obj/machinery/computer/communications/proc/make_announcement(mob/living/user, is_silicon)
 	var/input = stripped_input(user, "Please choose a message to announce to the station crew.", "What?")
-	if(!input || !user.canUseTopic(src))
+	if(!input || !user.canUseTopic(src) || (message_cooldown && !is_silicon) || (ai_message_cooldown && is_silicon))
 		return
+
 	if(is_silicon)
 		minor_announce(input)
 		ai_message_cooldown = 1
@@ -581,6 +582,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 		message_cooldown = 1
 		spawn(600)//One minute cooldown
 			message_cooldown = 0
+	
 	log_say("[key_name(user)] has made a priority announcement: [input]")
 	message_admins("[key_name_admin(user)] has made a priority announcement.")
 

--- a/html/changelogs/JohnGinnane - fixCommsConsoleSpamAgain.yml
+++ b/html/changelogs/JohnGinnane - fixCommsConsoleSpamAgain.yml
@@ -1,0 +1,6 @@
+author: John Ginnane
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed users being able to spam priority announcements."


### PR DESCRIPTION
Added more conditions to the make_announcement proc so it will return if either cooldown is active.

Fixes #2317
Fixes #2318
