### PR TITLE
Improve travis script error checker

### DIFF
--- a/dm.sh
+++ b/dm.sh
@@ -79,7 +79,7 @@ else
 	then
 		DreamMaker $dmepath.mdme 2>&1 | tee result.log
 		retval=$?
-		if ! grep '0 errors, 0 warnings' result.log
+		if ! grep '\- 0 errors, 0 warnings' result.log
 		then
 			retval=1 #hard fail, due to warnings or errors
 		fi


### PR DESCRIPTION
Builds should not pass when they have an error count that is a multiple of 10

basically a dreammaker output of 
- 10 errors and 0 warnings was matching the grep  like so : - 1[0 errors and 0 warnings]
  the new grep doesn't match, as it looks for the - as well, so it will now only match
- 0 errors and 0 warnings.
