### PR TITLE
Grinder Fix + Updates

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -969,18 +969,25 @@
 				/obj/item/stack/sheet/mineral/bananium = list("banana" = 20),
 				/obj/item/stack/sheet/mineral/silver = list("silver" = 20),
 				/obj/item/stack/sheet/mineral/gold = list("gold" = 20),
+				/obj/item/weapon/coin/gold = list("gold" = 4),
+				/obj/item/weapon/coin/silver = list("silver" = 4),
+				/obj/item/weapon/coin/iron = list("iron" = 4),
+				/obj/item/weapon/coin/plasma = list("plasma" = 4),
+				/obj/item/weapon/coin/uranium = list("uranium" = 4),
+				/obj/item/weapon/coin/clown = list("banana" = 4),
 				/obj/item/weapon/grown/nettle/basic = list("sacid" = 0),
 				/obj/item/weapon/grown/nettle/death = list("facid" = 0),
 				/obj/item/weapon/grown/novaflower = list("capsaicin" = 0, "condensedcapsaicin" = 0),
 
 				//Crayons (for overriding colours)
-				/obj/item/toy/crayon/red = list("redcrayonpowder" = 10),
-				/obj/item/toy/crayon/orange = list("orangecrayonpowder" = 10),
-				/obj/item/toy/crayon/yellow = list("yellowcrayonpowder" = 10),
-				/obj/item/toy/crayon/green = list("greencrayonpowder" = 10),
-				/obj/item/toy/crayon/blue = list("bluecrayonpowder" = 10),
-				/obj/item/toy/crayon/purple = list("purplecrayonpowder" = 10),
+				/obj/item/toy/crayon/red = list("redcrayonpowder" = 50),
+				/obj/item/toy/crayon/orange = list("orangecrayonpowder" = 50),
+				/obj/item/toy/crayon/yellow = list("yellowcrayonpowder" = 50),
+				/obj/item/toy/crayon/green = list("greencrayonpowder" = 50),
+				/obj/item/toy/crayon/blue = list("bluecrayonpowder" = 50),
+				/obj/item/toy/crayon/purple = list("purplecrayonpowder" = 50),
 				/obj/item/toy/crayon/mime = list("invisiblecrayonpowder" = 50),
+				/obj/item/toy/crayon/rainbow = list("colorful_reagent" = 100),
 
 				//Blender Stuff
 				/obj/item/weapon/reagent_containers/food/snacks/grown/soybeans = list("soymilk" = 0),
@@ -998,14 +1005,15 @@
 				/obj/item/weapon/reagent_containers/food/snacks/grown/tea/aspera = list("teapowder" = 0),
 				/obj/item/weapon/reagent_containers/food/snacks/grown/tea/astra = list("teapowder" = 0, "salglu_solution" = 0),
 
-
-
+				//Random Meme-tier stuff!!
+				/obj/item/weapon/screwdriver = list("screwdrivercocktail" = 30),
+				/obj/item/organ/internal/butt = list("fartium" = 20),
+				/obj/item/clothing/mask/cigarette = list("nicotine" = 15),
+				/obj/item/weapon/storage/book/bible = list("holywater" = 100),
+				
 				//All types that you can put into the grinder to transfer the reagents to the beaker. !Put all recipes above this.!
 				/obj/item/weapon/reagent_containers/pill = list(),
-				/obj/item/weapon/reagent_containers/food = list(),
-
-				//Random Meme-tier stuff!!
-				/obj/item/weapon/screwdriver = list("screwdrivercocktail" = 30)
+				/obj/item/weapon/reagent_containers/food = list()
 		)
 
 		var/list/juice_items = list (
@@ -1096,7 +1104,7 @@
 				src.updateUsrDialog()
 				return 0
 
-		if (!is_type_in_list(O, blend_items) && !is_type_in_list(O, juice_items))
+		if (!is_type_in_list(O, blend_items) && !is_type_in_list(O, juice_items) && !istype(O, obj/item/weapon/reagent_containers/food))
 				user << "<span class='warning'>Cannot refine into a reagent!</span>"
 				return 1
 

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -1008,12 +1008,12 @@
 				//Random Meme-tier stuff!!
 				/obj/item/weapon/screwdriver = list("screwdrivercocktail" = 30),
 				/obj/item/organ/internal/butt = list("fartium" = 20),
-				/obj/item/clothing/mask/cigarette = list("nicotine" = 15),
 				/obj/item/weapon/storage/book/bible = list("holywater" = 100),
 				
 				//All types that you can put into the grinder to transfer the reagents to the beaker. !Put all recipes above this.!
 				/obj/item/weapon/reagent_containers/pill = list(),
-				/obj/item/weapon/reagent_containers/food = list()
+				/obj/item/weapon/reagent_containers/food = list(),
+				/obj/item/clothing/mask/cigarette = list()
 		)
 
 		var/list/juice_items = list (
@@ -1104,7 +1104,7 @@
 				src.updateUsrDialog()
 				return 0
 
-		if (!is_type_in_list(O, blend_items) && !is_type_in_list(O, juice_items) && !istype(O,/obj/item/weapon/reagent_containers/food))
+		if (!is_type_in_list(O, blend_items) && !is_type_in_list(O, juice_items) && !istype(O, /obj/item/weapon/reagent_containers/food) && !istype(O, /obj/item/weapon/reagent_containers/pill) && !istype(O, /obj/item/clothing/mask/cigarette))
 				user << "<span class='warning'>Cannot refine into a reagent!</span>"
 				return 1
 

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -1104,7 +1104,7 @@
 				src.updateUsrDialog()
 				return 0
 
-		if (!is_type_in_list(O, blend_items) && !is_type_in_list(O, juice_items) && !istype(O, obj/item/weapon/reagent_containers/food))
+		if (!is_type_in_list(O, blend_items) && !is_type_in_list(O, juice_items) && !istype(O,/obj/item/weapon/reagent_containers/food))
 				user << "<span class='warning'>Cannot refine into a reagent!</span>"
 				return 1
 

--- a/html/changelogs/ArcLumin - Grinder Fix + Changes
+++ b/html/changelogs/ArcLumin - Grinder Fix + Changes
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: ArcLumin
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Adds coin grinding, gives 4u of respective chem"
+  - rscadd: "Adds butt grinding, gives 20u of fartium"
+  - rscadd: "Adds cigarette grinding, gives 15u of nicotine"
+  - rscadd: "Adds bible grinding, gives 100u of holy water"
+  - rscadd: "Adds rainbow crayon grinding, gives 100u of colorful reagent"
+  - tweak: "Increases crayon powder amount via grinding from 10u to 50u"
+  - bugfix: "Fixes grinder being unable to grind food. Finally."

--- a/html/changelogs/ArcLumin - Grinder Fix + Changes
+++ b/html/changelogs/ArcLumin - Grinder Fix + Changes
@@ -35,8 +35,8 @@ delete-after: True
 changes: 
   - rscadd: "Adds coin grinding, gives 4u of respective chem"
   - rscadd: "Adds butt grinding, gives 20u of fartium"
-  - rscadd: "Adds cigarette grinding, gives 15u of nicotine"
+  - rscadd: "Adds cigarette grinding, gives all the reagents contained"
   - rscadd: "Adds bible grinding, gives 100u of holy water"
   - rscadd: "Adds rainbow crayon grinding, gives 100u of colorful reagent"
   - tweak: "Increases crayon powder amount via grinding from 10u to 50u"
-  - bugfix: "Fixes grinder being unable to grind food. Finally."
+  - bugfix: "Fixes grinder being unable to grind food and pills. Finally."


### PR DESCRIPTION
Adds in coin grinding, butt grinding for fartium, cig grinding for nicotine, bible grinding for holy water, rainbow crayon grinding for colorful reagent, increases crayon powder amounts. Fixes grinder being unable to grind food.
