### PR TITLE
Multiple High Priority Supermatter Fixes

### DIFF
--- a/html/changelogs/Gandalf2k15 - Supermatter Fix.yml
+++ b/html/changelogs/Gandalf2k15 - Supermatter Fix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Gandalf2k15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Multiple supermatter bugfixes."


### PR DESCRIPTION
Fixes multiple game breaking issues with the supermatter, they are as follows.
1. The supermatter used Del() instead of Destroy(), addressed.
2. The supermatter used del to remove itself upon explosion, replaced with qdel in conjunction with Destroy().
3. The suppermatter never logged or created a noise when it consumed someone or something.
4. The supermatter never irradiated properly when it was bumped into, now uses radiation_pulse.
5. The supermatter SILENTLY created a stage six singularity, with no log or sound. IT now does.
6. On consumption it never logged, now it does along with the fix for consuming mechs and containers.

Fixes https://github.com/HippieStationCode/HippieStation13/issues/2592
