### PR TITLE
Improve overlay code for taperecorder tapes

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -257,7 +257,8 @@
 
 
 /obj/item/device/tape/proc/ruin()
-	overlays += "ribbonoverlay"
+	if(!ruined) //only add the ruin overlay once when ruined
+		overlays += "ribbonoverlay"
 	ruined = 1
 
 


### PR DESCRIPTION
This can cause pathological performance when the item is set on fire and fireact
is called repeatedly.

Fixes this by only adding the ruined tape overlay once.

See also https://github.com/tgstation/tgstation/pull/19667
