### PR TITLE
Makes inflatable walls less strong and abusable.

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -7,15 +7,16 @@
 	var/structuretype = /obj/structure/inflatable
 
 /obj/item/inflatable/attack_self(mob/user)
-	if(locate(/obj/structure/inflatable) in user.loc)	
+	if(locate(/obj/structure/inflatable) in user.loc)
 		user << "<span class='warning'>You cannot place inflatable walls upon eachother!</span>"
 		return
 	playsound(loc, 'sound/items/zip.ogg', 75, 1)
 	user << "<span class='notice'>You inflate [src].</span>"
-	var/obj/structure/inflatable/R = new structuretype(user.loc)
-	transfer_fingerprints_to(R)
-	R.add_fingerprint(user)
-	qdel(src)
+	if(do_mob(user, src, 10))
+		var/obj/structure/inflatable/R = new structuretype(user.loc)
+		transfer_fingerprints_to(R)
+		R.add_fingerprint(user)
+		qdel(src)
 
 /obj/structure/inflatable
 	name = "inflatable wall"
@@ -25,7 +26,7 @@
 	opacity = 0
 	icon = 'icons/obj/inflatable.dmi'
 	icon_state = "wall"
-	var/health = 50
+	var/health = 20
 	var/torntype = /obj/item/inflatable/torn
 	var/itemtype = /obj/item/inflatable
 

--- a/html/changelogs/Kokojo - inflatable.yml
+++ b/html/changelogs/Kokojo - inflatable.yml
@@ -1,0 +1,6 @@
+author: Kokojo
+
+delete-after: True
+
+changes: 
+  - tweak: "Inflatable barriers HP lowered to 20 from 50, and now require a (very)small delay to deploy."


### PR DESCRIPTION
Fixes #2710

Reduces Inflatable HP from 50 to 20. (Still 3 crowbar hit)
Makes them have a (very small) deploy phase, (I tested and space-pull dosen't stop you), so you can't deploy them while running.
