### PR TITLE
spray tan tweaks

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -96,7 +96,7 @@
 /proc/random_skin_tone()
 	var/list/valid_skin_tones = skin_tones
 	valid_skin_tones -= "orange"
-	return pick(skin_tones)
+	return pick(valid_skin_tones)
 
 var/list/skin_tones = list(
 	"albino",

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -108,7 +108,8 @@ var/list/skin_tones = list(
 	"arab",
 	"indian",
 	"african1",
-	"african2"
+	"african2",
+	"orange"
 	)
 
 var/global/list/species_list[0]

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -94,6 +94,8 @@
 			break
 
 /proc/random_skin_tone()
+	var/list/valid_skin_tones = skin_tones
+	valid_skin_tones -= "orange"
 	return pick(skin_tones)
 
 var/list/skin_tones = list(

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -655,6 +655,8 @@ var/global/list/limb_icon_cache = list()
 /proc/skintone2hex(var/skin_tone)
 	. = 0
 	switch(skin_tone)
+		if("orange")
+			. = "ff8800"
 		if("caucasian1")
 			. = "ffe0d1"
 		if("caucasian2")

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -340,6 +340,7 @@
 	if(istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/N = M
 		if(N.dna.species.id == "human") // If they're human, turn em to the "orange" race, and give em spiky black hair
+			N.facial_hair_color = "f80"
 			N.skin_tone = "orange"
 			N.hair_style = "Spiky"
 			N.hair_color = "000"

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -339,6 +339,7 @@
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/N = M
 			if(N.dna.species.id == "human") // If they're human, turn em to the "orange" race, and give em spiky black hair
+				N << "<span class='userdanger'>You feel like you have had too much of [name]!</span>"
 				N.facial_hair_color = "f80"
 				N.skin_tone = "orange"
 				N.hair_style = "Spiky"

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -279,7 +279,7 @@
 
 /datum/reagent/spraytan/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(istype(M, /mob/living/carbon/human))
-		if(method == PATCH || method == VAPOR)
+		if(method == PATCH || method == VAPOR || method == TOUCH)
 			var/mob/living/carbon/human/N = M
 			if(N.dna.species.id == "human")
 				switch(N.skin_tone)

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -333,6 +333,30 @@
 			M.AdjustWeakened(2)
 	..()
 
+	if(reac_volume > 11)
+		metabolization_rate = 1 * REAGENTS_METABOLISM
+
+		if(istype(M, /mob/living/carbon/human))
+			var/mob/living/carbon/human/N = M
+			if(N.dna.species.id == "human") // If they're human, turn em to the "orange" race, and give em spiky black hair
+				N.facial_hair_color = "f80"
+				N.skin_tone = "orange"
+				N.hair_style = "Spiky"
+				N.hair_color = "000"
+				N.update_hair()
+			if(MUTCOLORS in N.dna.species.specflags) //Aliens with custom colors simply get turned orange
+				N.dna.features["mcolor"] = "f80"
+				N.regenerate_icons()
+			N.update_body()
+			if(prob(7))
+				if(N.w_uniform)
+					M.visible_message(pick("<b>[M]</b>'s collar pops up without warning.</span>", "<b>[M]</b> flexes their arms."))
+				else
+					M.visible_message("<b>[M]</b> flexes their arms.")
+		if(prob(10))
+			M.say(pick("Check these sweet biceps bro!", "Deal with it.", "CHUG! CHUG! CHUG! CHUG!", "Winning!", "NERDS!", "My name is John and I hate every single one of you."))
+	..()
+	return
 
 /datum/reagent/spraytan/overdose_process(mob/living/M)
 	metabolization_rate = 1 * REAGENTS_METABOLISM

--- a/html/changelogs/Varium - spraytanfix.yml
+++ b/html/changelogs/Varium - spraytanfix.yml
@@ -1,0 +1,14 @@
+author: Varium
+
+delete-after: True
+
+changes: 
+  - tweak: "Overdosing on spray tan now actually makes you orange."
+  - tweak: "Spray tan can now be splashed for its effects or used in smoke aswell."
+ 
+ 
+ 
+ 
+
+  
+  

--- a/html/changelogs/Varium - spraytanfix.yml
+++ b/html/changelogs/Varium - spraytanfix.yml
@@ -4,7 +4,7 @@ delete-after: True
 
 changes: 
   - tweak: "Overdosing on spray tan now actually makes you orange."
-  - tweak: "Spray tan can now be splashed for its effects or used in smoke aswell."
+  - tweak: "Spray tan can now be applied by splashing or via smoke."
  
  
  


### PR DESCRIPTION
Spraytan now actually makes you orange.
Spraytan now can be applied via splashing and smoke.

Just to make spray tan a tidy bit funnier and bringing back the original orange color on overdose.
