### PR TITLE
Handcuffs can now be used on people with one arm

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -31,9 +31,9 @@
 		return
 
 	if(!C.handcuffed)
-		if(C.get_num_arms() < 2)//Can only apply handcuffs on people with both arms)
-			user << "<span class='warning'>You cannot handcuff [C], they need to have two arms for that!</span>"
-			return
+			if(C.get_num_arms() < 1)//Can only apply handcuffs on people with both arms)
+				user << "<span class='warning'>You cannot handcuff [C], they have no arms!</span>"
+				return
 		C.visible_message("<span class='danger'>[user] is trying to put [src.name] on [C]!</span>", \
 							"<span class='userdanger'>[user] is trying to put [src.name] on [C]!</span>")
 

--- a/html/changelogs/Kokojo - hancuffs.yml
+++ b/html/changelogs/Kokojo - hancuffs.yml
@@ -1,0 +1,6 @@
+author: Kokojo
+
+delete-after: True
+
+changes:
+  - tweak: "You can now handcuff people with one arm, like in reality."


### PR DESCRIPTION
Does what it says on the tin.

Like in reality, you can still handcuff people with one arm by going for their leg, beltbuckles, shorts, or intertwining the cuffs so that people can't use their arm properly.
