### PR TITLE
Unholy Water and Holy Water tweaks

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -85,7 +85,7 @@ It also contains rune words, which are soon to be removed.
 		var/holy2unholy = A.reagents.get_reagent_amount("holywater")
 		A.reagents.del_reagent("holywater")
 		A.reagents.add_reagent("unholywater",holy2unholy)
-		add_logs(user, M, "smacked", src, " removing the holy water from them")
+		add_logs(user, A, "smacked", src, " removing the holy water from them")
 	
 /obj/item/weapon/tome/attack_self(mob/user)
 	if(!iscultist(user))

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -81,11 +81,11 @@ It also contains rune words, which are soon to be removed.
 	if(!proximity)
 		return
 	if(A.reagents && A.reagents.has_reagent("holywater")) //allows cultists to be rescued from the clutches of ordained religion
-	user << "<span class='notice'>You remove the taint from [A].</span>"
-	var/holy2unholy = A.reagents.get_reagent_amount("holywater")
-	A.reagents.del_reagent("holywater")
-	A.reagents.add_reagent("unholywater",holy2unholy)
-	add_logs(user, M, "smacked", src, " removing the holy water from them")
+		user << "<span class='notice'>You remove the taint from [A].</span>"
+		var/holy2unholy = A.reagents.get_reagent_amount("holywater")
+		A.reagents.del_reagent("holywater")
+		A.reagents.add_reagent("unholywater",holy2unholy)
+		add_logs(user, M, "smacked", src, " removing the holy water from them")
 	
 /obj/item/weapon/tome/attack_self(mob/user)
 	if(!iscultist(user))

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -69,14 +69,6 @@ It also contains rune words, which are soon to be removed.
 		return
 	if(!iscultist(user))
 		return ..()
-	if(iscultist(M))
-		if(M.reagents && M.reagents.has_reagent("holywater")) //allows cultists to be rescued from the clutches of ordained religion
-			user << "<span class='notice'>You remove the taint from [M].</span>"
-			var/holy2unholy = M.reagents.get_reagent_amount("holywater")
-			M.reagents.del_reagent("holywater")
-			M.reagents.add_reagent("unholywater",holy2unholy)
-			add_logs(user, M, "smacked", src, " removing the holy water from them")
-		return
 	M.take_organ_damage(0, 15) //Used to be a random between 5 and 20
 	playsound(M, 'sound/weapons/sear.ogg', 50, 1)
 	M.visible_message("<span class='danger'>[user] strikes [M] with the arcane tome!</span>", \
@@ -84,7 +76,17 @@ It also contains rune words, which are soon to be removed.
 	flick("tome_attack", src)
 	user.do_attack_animation(M)
 	add_logs(user, M, "smacked", src)
-
+	
+/obj/item/weapon/tome/afterattack(atom/A, mob/user, proximity)
+	if(!proximity)
+		return
+	if(A.reagents && A.reagents.has_reagent("holywater")) //allows cultists to be rescued from the clutches of ordained religion
+	user << "<span class='notice'>You remove the taint from [A].</span>"
+	var/holy2unholy = A.reagents.get_reagent_amount("holywater")
+	A.reagents.del_reagent("holywater")
+	A.reagents.add_reagent("unholywater",holy2unholy)
+	add_logs(user, M, "smacked", src, " removing the holy water from them")
+	
 /obj/item/weapon/tome/attack_self(mob/user)
 	if(!iscultist(user))
 		user << "<span class='warning'>[src] seems full of unintelligible shapes, scribbles, and notes. Is this some sort of joke?</span>"

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -227,13 +227,13 @@
 	stun_resist = 6
 
 /datum/reagent/fuel/unholywater/on_mob_life(mob/living/M)
-	M.adjustBrainLoss(3)
 	if(iscultist(M))
 		speedboost = FAST
 		M.drowsyness = max(M.drowsyness-5, 0)
 		stun_resist_act(M)
 	else
 		speedboost = NORMAL
+		M.adjustBrainLoss(3)
 		M.adjustToxLoss(2)
 		M.adjustFireLoss(2)
 		M.adjustOxyLoss(2)

--- a/code/modules/reagents/Chemistry-Recipes/Others.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Others.dm
@@ -438,6 +438,13 @@
 	required_reagents = list("sodium" = 1, "hydrogen" = 1, "oxygen" = 3)
 	result_amount = 3
 	
+/datum/chemical_reaction/holywater
+	name = "Holy Water"
+	id = "holywater"
+	result = "holywater"
+	required_reagents = list("wine" = 1, "blood" = 1, "water" = 1)
+	result_amount = 3
+	
 //////////////////////////////////// Solidification ///////////////////////////////////////////
 
 /datum/chemical_reaction/plasmasolidification

--- a/code/modules/reagents/Chemistry-Recipes/Others.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Others.dm
@@ -438,13 +438,6 @@
 	required_reagents = list("sodium" = 1, "hydrogen" = 1, "oxygen" = 3)
 	result_amount = 3
 	
-/datum/chemical_reaction/holywater
-	name = "Holy Water"
-	id = "holywater"
-	result = "holywater"
-	required_reagents = list("wine" = 1, "blood" = 1, "water" = 1)
-	result_amount = 3
-	
 //////////////////////////////////// Solidification ///////////////////////////////////////////
 
 /datum/chemical_reaction/plasmasolidification

--- a/html/changelogs/ArcLumin - Unholy.yml
+++ b/html/changelogs/ArcLumin - Unholy.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: ArcLumin
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Holy Water can now be made! Mix wine, blood, and water!"
+  - tweak: "Unholy water no longer braindamages cultists
+  - tweak: "Arcane tomes now properly can convert holy water in any object that can hold it, not just mobs.

--- a/html/changelogs/ArcLumin - Unholy.yml
+++ b/html/changelogs/ArcLumin - Unholy.yml
@@ -34,5 +34,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "Holy Water can now be made! Mix wine, blood, and water!"
-  - tweak: "Unholy water no longer braindamages cultists
-  - tweak: "Arcane tomes now properly can convert holy water in any object that can hold it, not just mobs.
+  - tweak: "Unholy water no longer braindamages cultists"
+  - tweak: "Arcane tomes now properly can convert holy water in any object that can hold it, not just mobs."


### PR DESCRIPTION
Unholy water now only braindamages non-cultists
Arcane tomes now properly use the afterattack like bibles rather than the on mob it had before, meaning it can now change holy water to unholy water in anything that can hold reagents
removed holy water chem recipe due to people not liking it
