### PR TITLE
Lets admins grant any objective instead of traitor only ones + crew obj bugfixes

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -370,7 +370,7 @@ var/list/datum/objective/crew/trackedcrewobjs = list()
 	if(config.minimal_access_threshold)
 		H << "<FONT color='blue'><B>As this station was initially staffed with a [config.jobs_have_minimal_access ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B></font>"
 
-	if(H.mind)
+	if(H.mind && !joined_late)
 		H.mind.assigned_role = rank
 		forge_job_objectives(H.mind, rank)
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -623,7 +623,7 @@
 	else
 		var/obj_count = 1
 		for(var/datum/objective/objective in objectives)
-			out += "<B>[obj_count]</B>: [objective.explanation_text] <a href='?src=\ref[src];obj_edit=\ref[objective]'>Edit</a> <a href='?src=\ref[src];obj_delete=\ref[objective]'>Delete</a> <a href='?src=\ref[src];obj_completed=\ref[objective]'><font color=[objective.completed ? "green" : "red"]>Toggle Completion</font></a><br>"
+			out += "<B>[obj_count]</B>: [objective.explanation_text] <a href='?src=\ref[src];obj_delete=\ref[objective]'>Delete</a> <a href='?src=\ref[src];obj_completed=\ref[objective]'><font color=[objective.completed ? "green" : "red"]>Toggle Completion</font></a><br>"
 			obj_count++
 	out += "<a href='?src=\ref[src];obj_add=1'>Add objective</a><br><br>"
 
@@ -644,154 +644,33 @@
 		if (isnull(new_memo)) return
 		memory = new_memo
 
-	else if (href_list["obj_edit"] || href_list["obj_add"])
+	else if (href_list["obj_add"])
 		var/datum/objective/objective
-		var/objective_pos
-		var/def_value
 
-		if (href_list["obj_edit"])
-			objective = locate(href_list["obj_edit"])
-			if (!objective) return
-			objective_pos = objectives.Find(objective)
+		var/list/blacklist = list(/datum/objective, /datum/objective/crew, /datum/objective/changeling_team_objective)
+		for(var/i in departments)
+			blacklist += i
+		var/datum/objective/new_objective
+		var/list/possibleobjs = (typesof(/datum/objective) - blacklist) + "custom"
+		var/new_obj_type = input("Select objective type:", "Objective type") as null|anything in possibleobjs
+		if(!new_obj_type) return
 
-			//Text strings are easy to manipulate. Revised for simplicity.
-			var/temp_obj_type = "[objective.type]"//Convert path into a text string.
-			def_value = copytext(temp_obj_type, 19)//Convert last part of path into an objective keyword.
-			if(!def_value)//If it's a custom objective, it will be an empty string.
-				def_value = "custom"
+		if(new_obj_type != "custom")
+			new_objective = new new_obj_type(themind = src)
+			new_objective.select_target()
+			new_objective.update_explanation_text()
+		else
+			var/expl = stripped_input(usr, "Custom objective:", "Objective", objective ? objective.explanation_text : "")
+			if (!expl) return
+			new_objective = new /datum/objective(text = expl, themind = src)
 
-		var/new_obj_type = input("Select objective type:", "Objective type", def_value) as null|anything in list("assassinate", "maroon", "debrain", "protect", "destroy", "prevent", "hijack", "escape", "survive", "martyr", "steal", "download", "nuclear", "capture", "absorb","follower block (HOG)","build (HOG)","deicide (HOG)", "follower escape (HOG)", "sacrifice prophet (HOG)", "custom")
-		if (!new_obj_type) return
+		if(!new_objective) return
 
-		var/datum/objective/new_objective = null
-
-		switch (new_obj_type)
-			if ("assassinate","protect","debrain","maroon")
-				var/list/possible_targets = list("Free objective")
-				for(var/datum/mind/possible_target in ticker.minds)
-					if ((possible_target != src) && istype(possible_target.current, /mob/living/carbon/human))
-						possible_targets += possible_target.current
-
-				var/mob/def_target = null
-				var/objective_list[] = list(/datum/objective/assassinate, /datum/objective/protect, /datum/objective/debrain, /datum/objective/maroon)
-				if (objective&&(objective.type in objective_list) && objective:target)
-					def_target = objective:target.current
-
-				var/new_target = input("Select target:", "Objective target", def_target) as null|anything in possible_targets
-				if (!new_target) return
-
-				var/objective_path = text2path("/datum/objective/[new_obj_type]")
-				if (new_target == "Free objective")
-					new_objective = new objective_path
-					new_objective.owner = src
-					new_objective:target = null
-					new_objective.explanation_text = "Free objective"
-				else
-					new_objective = new objective_path
-					new_objective.owner = src
-					new_objective:target = new_target:mind
-					//Will display as special role if the target is set as MODE. Ninjas/commandos/nuke ops.
-					new_objective.update_explanation_text()
-
-			if ("destroy")
-				var/list/possible_targets = active_ais(1)
-				if(possible_targets.len)
-					var/mob/new_target = input("Select target:", "Objective target") as null|anything in possible_targets
-					new_objective = new /datum/objective/destroy
-					new_objective.target = new_target.mind
-					new_objective.owner = src
-					new_objective.update_explanation_text()
-				else
-					usr << "No active AIs with minds"
-
-			if ("prevent")
-				new_objective = new /datum/objective/block
-				new_objective.owner = src
-
-			if ("hijack")
-				new_objective = new /datum/objective/hijack
-				new_objective.owner = src
-
-			if ("escape")
-				new_objective = new /datum/objective/escape
-				new_objective.owner = src
-
-			if ("survive")
-				new_objective = new /datum/objective/survive
-				new_objective.owner = src
-
-			if("martyr")
-				new_objective = new /datum/objective/martyr
-				new_objective.owner = src
-
-			if ("nuclear")
-				new_objective = new /datum/objective/nuclear
-				new_objective.owner = src
-
-			if ("steal")
-				if (!istype(objective, /datum/objective/steal))
-					new_objective = new /datum/objective/steal
-					new_objective.owner = src
-				else
-					new_objective = objective
-				var/datum/objective/steal/steal = new_objective
-				if (!steal.select_target())
-					return
-
-			if("download","capture","absorb")
-				var/def_num
-				if(objective&&objective.type==text2path("/datum/objective/[new_obj_type]"))
-					def_num = objective.target_amount
-
-				var/target_number = input("Input target number:", "Objective", def_num) as num|null
-				if (isnull(target_number))//Ordinarily, you wouldn't need isnull. In this case, the value may already exist.
-					return
-
-				switch(new_obj_type)
-					if("download")
-						new_objective = new /datum/objective/download
-						new_objective.explanation_text = "Download [target_number] research levels."
-					if("capture")
-						new_objective = new /datum/objective/capture
-						new_objective.explanation_text = "Capture [target_number] lifeforms with an energy net. Live, rare specimens are worth more."
-					if("absorb")
-						new_objective = new /datum/objective/absorb
-						new_objective.explanation_text = "Absorb [target_number] compatible genomes."
-				new_objective.owner = src
-				new_objective.target_amount = target_number
-
-			if("follower block (HOG)")
-				new_objective = new /datum/objective/follower_block
-				new_objective.owner = src
-			if("build (HOG)")
-				new_objective = new /datum/objective/build
-				new_objective.owner = src
-			if("deicide (HOG)")
-				new_objective = new /datum/objective/deicide
-				new_objective.owner = src
-			if("follower escape (HOG)")
-				new_objective = new /datum/objective/escape_followers
-				new_objective.owner = src
-			if("sacrifice prophet (HOG)")
-				new_objective = new /datum/objective/sacrifice_prophet
-				new_objective.owner = src
-
-			if ("custom")
-				var/expl = stripped_input(usr, "Custom objective:", "Objective", objective ? objective.explanation_text : "")
-				if (!expl) return
-				new_objective = new /datum/objective
-				new_objective.owner = src
-				new_objective.explanation_text = expl
-
-		if (!new_objective) return
-
-		if (objective)
+		if(objective)
 			objectives -= objective
-			objectives.Insert(objective_pos, new_objective)
 			message_admins("[key_name_admin(usr)] edited [current]'s objective to [new_objective.explanation_text]")
 			log_admin("[key_name(usr)] edited [current]'s objective to [new_objective.explanation_text]")
 		else
-			objectives += new_objective
 			message_admins("[key_name_admin(usr)] added a new objective for [current]: [new_objective.explanation_text]")
 			log_admin("[key_name(usr)] added a new objective for [current]: [new_objective.explanation_text]")
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -645,8 +645,6 @@
 		memory = new_memo
 
 	else if (href_list["obj_add"])
-		var/datum/objective/objective
-
 		var/list/blacklist = list(/datum/objective, /datum/objective/crew, /datum/objective/changeling_team_objective)
 		for(var/i in departments)
 			blacklist += i
@@ -660,19 +658,14 @@
 			new_objective.select_target()
 			new_objective.update_explanation_text()
 		else
-			var/expl = stripped_input(usr, "Custom objective:", "Objective", objective ? objective.explanation_text : "")
+			var/expl = stripped_input(usr, "Custom objective:", "Objective")
 			if (!expl) return
 			new_objective = new /datum/objective(text = expl, themind = src)
 
 		if(!new_objective) return
 
-		if(objective)
-			objectives -= objective
-			message_admins("[key_name_admin(usr)] edited [current]'s objective to [new_objective.explanation_text]")
-			log_admin("[key_name(usr)] edited [current]'s objective to [new_objective.explanation_text]")
-		else
-			message_admins("[key_name_admin(usr)] added a new objective for [current]: [new_objective.explanation_text]")
-			log_admin("[key_name(usr)] added a new objective for [current]: [new_objective.explanation_text]")
+		message_admins("[key_name_admin(usr)] added a new objective for [current]: [new_objective.explanation_text]")
+		log_admin("[key_name(usr)] added a new objective for [current]: [new_objective.explanation_text]")
 
 	else if (href_list["obj_delete"])
 		var/datum/objective/objective = locate(href_list["obj_delete"])

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -76,6 +76,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 				if(age_check(character.client))
 					if(!(character.job in restricted_jobs))
 						character.mind.make_Changling()
+						return 1
 
 /datum/game_mode/proc/forge_changeling_objectives(datum/mind/changeling)
 	//OBJECTIVES - random traitor objectives. Unique objectives "steal brain" and "identity theft".

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -71,4 +71,5 @@
 				if(age_check(character.client))
 					if(!(character.job in restricted_jobs))
 						character.mind.make_Changling()
+						return 1
 	..()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -92,7 +92,7 @@
 ///Handles late-join antag assignments
 /datum/game_mode/proc/make_antag_chance(mob/living/carbon/human/character)
 	if(replacementmode && round_converted == 2)
-		replacementmode.make_antag_chance(character)
+		return replacementmode.make_antag_chance(character)
 	return
 
 ///convert_roundtype()

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -70,6 +70,7 @@
 	return 1
 
 /datum/game_mode/traitor/make_antag_chance(mob/living/carbon/human/character) //Assigns traitor to latejoiners
+	..()
 	var/traitorcap = min(round(joined_player_list.len / (config.traitor_scaling_coeff * 2)) + 2 + num_modifier, round(joined_player_list.len/config.traitor_scaling_coeff) + num_modifier )
 	if(ticker.mode.traitors.len >= traitorcap) //Upper cap for number of latejoin antagonists
 		return
@@ -79,6 +80,7 @@
 				if(age_check(character.client))
 					if(!(character.job in restricted_jobs))
 						add_latejoin_traitor(character.mind)
+						return 1
 
 /datum/game_mode/traitor/proc/add_latejoin_traitor(datum/mind/character)
 	character.make_Traitor()

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -215,13 +215,9 @@ var/list/possibleRevenantNames = list("Lust", "Gluttony", "Greed", "Sloth", "Wra
 			src << "<b>To function, you are to drain the life essence from humans. This essence is a resource, as well as your health, and will power all of your abilities.</b>"
 			src << "<b><i>You do not remember anything of your past lives, nor will you remember anything about this one after your death.</i></b>"
 			src << "<b>Be sure to read the wiki page at http://wiki.hippiestation.com/index.php?title=Revenant to learn more.</b>"
-			var/datum/objective/revenant/objective = new
-			objective.owner = src.mind
-			src.mind.objectives += objective
+			var/datum/objective/revenant/objective = new(mind)
 			src << "<b>Objective #1</b>: [objective.explanation_text]"
-			var/datum/objective/revenantFluff/objective2 = new
-			objective2.owner = src.mind
-			src.mind.objectives += objective2
+			var/datum/objective/revenantFluff/objective2 = new(mind)
 			src.mind.name = name
 			real_name = name
 			src << "<b>Objective #2</b>: [objective2.explanation_text]"
@@ -297,7 +293,7 @@ var/list/possibleRevenantNames = list("Lust", "Gluttony", "Greed", "Sloth", "Wra
 	dangerrating = 10
 	var/targetAmount = 100
 
-/datum/objective/revenant/New()
+/datum/objective/revenant/New(datum/mind/target, text, datum/mind/themind)
 	targetAmount = rand(200,500)
 	explanation_text = "Absorb [targetAmount] points of essence from humans."
 	..()
@@ -316,7 +312,7 @@ var/list/possibleRevenantNames = list("Lust", "Gluttony", "Greed", "Sloth", "Wra
 /datum/objective/revenantFluff
 	dangerrating = 0
 
-/datum/objective/revenantFluff/New()
+/datum/objective/revenantFluff/New(datum/mind/target, text, datum/mind/themind)
 	var/list/explanationTexts = list("Attempt to make your presence unknown to the crew.", \
 									 "Collaborate with existing antagonists aboard the station to gain essence.", \
 									 "Remain nonlethal and only absorb bodies that have already died.", \

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -306,7 +306,6 @@
 					if(ticker.mode.make_antag_chance(character))
 						antag = TRUE
 	if(!antag && character.mind)
-		world << "fuck"
 		SSjob.forge_job_objectives(character.mind, rank)
 	qdel(src)
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -295,13 +295,19 @@
 
 	joined_player_list += character.ckey
 
+	var/antag = FALSE
 	if(config.allow_latejoin_antagonists)
 		switch(SSshuttle.emergency.mode)
 			if(SHUTTLE_RECALL, SHUTTLE_IDLE)
-				ticker.mode.make_antag_chance(character)
+				if(ticker.mode.make_antag_chance(character))
+					antag = TRUE
 			if(SHUTTLE_CALL)
 				if(SSshuttle.emergency.timeLeft(1) > initial(SSshuttle.emergencyCallTime)*0.5)
-					ticker.mode.make_antag_chance(character)
+					if(ticker.mode.make_antag_chance(character))
+						antag = TRUE
+	if(!antag && character.mind)
+		world << "fuck"
+		SSjob.forge_job_objectives(character.mind, rank)
 	qdel(src)
 
 /mob/new_player/proc/AnnounceArrival(var/mob/living/carbon/human/character, var/rank)

--- a/html/changelogs/Carbonhell - Crewfix.yml
+++ b/html/changelogs/Carbonhell - Crewfix.yml
@@ -1,4 +1,4 @@
-author: Badmex
+author: Carbonhell
 delete-after: True
 changes: 
   - tweak: "Admins can now give any objective and set the target easily."

--- a/html/changelogs/Carbonhell - Crewfix.yml
+++ b/html/changelogs/Carbonhell - Crewfix.yml
@@ -1,0 +1,6 @@
+author: Badmex
+delete-after: True
+changes: 
+  - tweak: "Admins can now give any objective and set the target easily."
+  - bugfix: "Fixed latejoiner antags having crew objectives."
+  - bugfix: "Fixed the have x chemical inside at roundend objective not actually requiring any chem."


### PR DESCRIPTION
- tweak: "Admins can now give any objective and set the target easily."
- bugfix: "Fixed latejoiner antags having crew objectives."
- bugfix: "Fixed the have x chemical inside at roundend objective not actually requiring any chem."
