### PR TITLE
Makes Bluespace and Sepia Flooring RnD makable

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -264,9 +264,9 @@ other types of metals and chemistry for reagents).
 	id = "bluefloor"
 	req_tech = list("bluespace" = 5, "materials" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_URANIUM = 100, MAT_DIAMOND = 100)
+	materials = list(MAT_URANIUM = 10, MAT_DIAMOND = 10)
 	reliability = 100
-	build_path = /obj/item/stack/tile/bluespace(src, 10)
+	build_path = /obj/item/stack/tile/bluespace
 	category = list("Bluespace Designs")
 	
 /datum/design/sepiafloor
@@ -275,9 +275,9 @@ other types of metals and chemistry for reagents).
 	id = "sepiafloor"
 	req_tech = list("bluespace" = 5, "materials" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_GOLD = 100, MAT_SILVER = 100)
+	materials = list(MAT_GOLD = 10, MAT_SILVER = 10)
 	reliability = 100
-	build_path = /obj/item/stack/tile/sepia(src, 10)
+	build_path = /obj/item/stack/tile/sepia
 	category = list("Bluespace Designs")
 
 

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -257,6 +257,28 @@ other types of metals and chemistry for reagents).
 	reliability = 100
 	build_path = /obj/item/organ/internal/butt/bluebutt
 	category = list("Bluespace Designs")
+	
+/datum/design/bluefloor
+	name = "Bluespace Floor Tile"
+	desc = "A flooring that makes you feel like you're teleporting!"
+	id = "bluefloor"
+	req_tech = list("bluespace" = 5, "materials" = 4)
+	build_type = PROTOLATHE
+	materials = list(MAT_URANIUM = 100, MAT_DIAMOND = 100)
+	reliability = 100
+	build_path = /obj/item/stack/tile/bluespace(src, 10)
+	category = list("Bluespace Designs")
+	
+/datum/design/sepiafloor
+	name = "Sepia Floor Tile"
+	desc = "A flooring that makes you feel like time is moving slower..."
+	id = "sepiafloor"
+	req_tech = list("bluespace" = 5, "materials" = 4)
+	build_type = PROTOLATHE
+	materials = list(MAT_GOLD = 100, MAT_SILVER = 100)
+	reliability = 100
+	build_path = /obj/item/stack/tile/sepia(src, 10)
+	category = list("Bluespace Designs")
 
 
 /////////////////////////////////////////

--- a/html/changelogs/ArcLumin - Flooring
+++ b/html/changelogs/ArcLumin - Flooring
@@ -1,0 +1,4 @@
+author: ArcLumin
+delete-after: True
+changes: 
+  - tweak: "Adds Sepia Flooring and Bluespace Flooring to RnD, as they were obscure and very underused"


### PR DESCRIPTION
Because xenobio literally never makes em. And they're pretty minor but really fun. Sepia requires gold and silver, bluespace requires uranium and diamond, both requiring bluespace research.
