### PR TITLE
Fixes #2866, talking while in crit will now parse HTML properly. Also fixes chatrooms having the same problem.

### DIFF
--- a/code/game/objects/items/devices/PDA/chatroom.dm
+++ b/code/game/objects/items/devices/PDA/chatroom.dm
@@ -49,7 +49,7 @@ var/list/chatchannels = list(default_ntrc_chatroom.name = default_ntrc_chatroom)
 			else
 				return "BAD_COMMAND"
 
-	return send_message(client,nick,message)
+	return send_message(html_decode(client),html_decode(nick),html_decode(message))
 
 //the following are helper procs, FOR INTERNAL USE ONLY
 
@@ -66,7 +66,7 @@ var/list/chatchannels = list(default_ntrc_chatroom.name = default_ntrc_chatroom)
 /datum/chatroom/proc/send_message(client,nick,message) //standard message
 	if(!message)
 		return 0
-	logs.Insert(1,"[html_encode(nick)]> [html_encode(message)]")
+	logs.Insert(1,"[html_decode(nick)]> [html_decode(message)]")
 	log_chat("[usr]/([usr.ckey]) as [nick] sent to [name]: [message]")
 	events.fireEvent("msg_chat",name,nick,message)
 	return 1
@@ -80,7 +80,7 @@ var/list/chatchannels = list(default_ntrc_chatroom.name = default_ntrc_chatroom)
 /datum/chatroom/proc/register_auth(client,nick) //register
 	if(!get_auth(client,nick))
 		return "BAD_REGS"
-	auth[client] = nick
+	auth[client] = html_decode(nick)
 	authed += nick
 	return 1
 

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -41,10 +41,10 @@
 		// If we cut our message short, abruptly end it with a-..
 		var/message_len = length(message)
 		message = copytext(message, 1, health_diff) + "[message_len > health_diff ? "-.." : "..."]"
-		message = Ellipsis(message, 10, 1)
+		message = Ellipsis(html_decode(message), 10, 1)
 		whispers = "whispers in their final breath"
 	else if(critical) //If whispering while in critical state but conscious
-		message = Ellipsis(message, 40, 1)
+		message = Ellipsis(html_decode(message), 40, 1)
 		whispers = "mutters"
 
 	message = treat_message(message)


### PR DESCRIPTION
Fixes #2866

![](http://i.imgur.com/gujrJfw.png)

![](http://i.imgur.com/TjoJMF5.png)

Before, any time someone talked while in crit or whispered their last breath, an apostrophe would show up as &#39; . This fixes it from my testing, nothing else happens that's unintended. This applies for both talking in crit along with last words stuff.

Also, the problem was the same in the chatroom, so I fixed that too. It's hack-y as shit but nobody uses the chatroom anyway and it is totally a fix.

![](http://i.imgur.com/gn8HnIj.png)
