### PR TITLE
Fixes Tablecrafting Error

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -69,8 +69,7 @@
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/weapon/gun/energy/gun/advtaser = 1,
 				/obj/item/weapon/stock_parts/cell = 1,
-				/obj/item/device/assembly/prox_sensor = 1,
-				/obj/item/robot_parts/r_arm = 1)
+				/obj/item/device/assembly/prox_sensor = 1)
 	tools = list(/obj/item/weapon/weldingtool, /obj/item/weapon/screwdriver)
 	time = 120
 	category = CAT_ROBOT

--- a/html/changelogs/ArcLumin - Arms.yml
+++ b/html/changelogs/ArcLumin - Arms.yml
@@ -1,0 +1,4 @@
+author: ArcLumin
+delete-after: True
+changes: 
+  - bugfix: "Fixes ED209's requiring arms to tablecraft"


### PR DESCRIPTION
ED209's don't require arms to make, so why the fuck do they need it for tablecrafting?
