### PR TITLE
Buffs Recycler

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -34,7 +34,7 @@ var/const/SAFETY_COOLDOWN = 100
 		mat_mod = 2 * B.rating
 	mat_mod *= 50000
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
-		amt_made = 25 * M.rating //% of materials salvaged
+		amt_made = 100 * M.rating //% of materials salvaged
 	materials.max_amount = mat_mod
 	amount_produced = min(100, amt_made)
 

--- a/html/changelogs/ArcLumin - Recycler.yml
+++ b/html/changelogs/ArcLumin - Recycler.yml
@@ -1,0 +1,4 @@
+author: ArcLumin
+delete-after: True
+changes: 
+  - tweak: "Makes the recycler actually useful, no longer makes it recycle 4 times less materials than what is put in, it gives 100% by default"


### PR DESCRIPTION
buffs recycler so it'll actually produce stuff. Before, you'd need to recycle like, 16 beakers for ONE glass sheet. Now it'll be 4 beakers for 1 sheet of glass

should fix https://github.com/HippieStationCode/HippieStation13/issues/2844

As it is now the autolathe does everything the recycler does but better. 

Let me know if you think this is too op of a buff
