### PR TITLE
Allows Surplus Crate to be purchasable during Nuke Ops or KotD

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1248,7 +1248,6 @@ var/list/uplink_items = list()
 	desc = "A crate containing 50 telecrystals worth of random syndicate leftovers."
 	cost = 20
 	item = /obj/item/weapon/storage/box/syndicate
-	excludefrom = list(/datum/game_mode/nuclear,/datum/game_mode/traitor/king_disk)
 
 /datum/uplink_item/badass/surplus_crate/spawn_item(turf/loc, obj/item/device/uplink/U)
 	var/obj/structure/closet/crate/C = new(loc)

--- a/html/changelogs/ArcLumin - Surplus.yml
+++ b/html/changelogs/ArcLumin - Surplus.yml
@@ -1,0 +1,4 @@
+author: ArcLumin
+delete-after: True
+changes: 
+  - tweak: "Allows Surplus Crates to be purchasable by nuke ops and during KotD"


### PR DESCRIPTION
It'd be a fun gimmick nuke ops to just get bulk random items, and you'd need a lot of time with the nuke disk to get the surplus crate in KotD
