### PR TITLE
Makes Life Reagent spawn by volume

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes/Others.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Others.dm
@@ -388,7 +388,7 @@
 	required_temp = 374
 
 /datum/chemical_reaction/life/on_reaction(datum/reagents/holder, created_volume)
-	chemical_mob_spawn(holder, 1, "Life")
+	chemical_mob_spawn(holder, 1*reac_volume, "Life")
 
 /datum/chemical_reaction/corgium
 	name = "corgium"


### PR DESCRIPTION
Rather than spawning 1 regardless of amount, it now spawns a mob dependant on how much is made.

It'll prolly fail but hey
