### PR TITLE
Adds traitor pyrotechnic kit and foof

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -143,8 +143,15 @@ var/list/uplink_items = list()
 	cost = 10
 	jobs = list("Chemist", "Medical Doctor", "Chief Medical Officer", "Geneticist", "Virologist")
 
-//SERVICE DIVISION
+//CHEMISTRY
+/datum/uplink_item/job_specific/syndipyro
+	name = "Syndicate Pyrotechnics"
+	desc = "A box of chemical weapons grade reagents approved by the Syndicate"
+	item = /obj/item/weapon/storage/box/syndie_kit/syndipyro
+	cost = 8
+	jobs = list("Chemist")
 
+//SERVICE DIVISION
 /datum/uplink_item/job_specific/chainsaw
 	name = "Chainsaw"
 	desc = "An extremely loud, dirty, noisy, bulky, powerful as hell chainsaw that will absolutely destroy anyone it comes in contact with. Obviously won't fit in your backpack."

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -322,3 +322,20 @@ obj/item/weapon/storage/box/syndie_kit/shotguntender
 	new /obj/item/ammo_casing/shotgun/incendiary/dragonsbreath(src)
 	new /obj/item/ammo_casing/shotgun/dart/bioterror(src)
 	return
+
+/obj/item/weapon/storage/box/syndie_kit/syndipyro
+	name = "boxed pyrotechnics kit"
+	storage_slots = 14
+
+/obj/item/weapon/storage/box/syndie_kit/syndipyro/New()
+	..()
+	new /obj/item/weapon/reagent_containers/glass/beaker/large/foof(src)
+	new /obj/item/weapon/reagent_containers/glass/bottle/nitroglycerin(src)
+	new /obj/item/weapon/reagent_containers/glass/bottle/nitroglycerin(src)
+	new /obj/item/weapon/reagent_containers/glass/bottle/thermite(src)
+	new /obj/item/weapon/reagent_containers/glass/bottle/phlogiston(src)
+	new /obj/item/weapon/reagent_containers/glass/bottle/napalm(src)
+	new /obj/item/weapon/reagent_containers/glass/bottle/clf3(src)
+	new /obj/item/weapon/reagent_containers/glass/bottle/cryogenic_fluid(src)
+	new /obj/item/weapon/reagent_containers/syringe(src)
+	return

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -304,3 +304,45 @@
 	desc = "A small bottle. Contains a sample of Inquisitius."
 	icon_state = "bottle3"
 	spawned_disease = /datum/disease/fluspanish
+
+/obj/item/weapon/reagent_containers/glass/beaker/large/foof
+	name = "Dioxygen Difluoride beaker"
+	desc = "Contains the exceptionally dangerous Dioxygen Difluoride. WARNING: Shelf life limited, will decay over time unless more cryogenic fluid is added."
+	icon_state = "beakerlarge"
+	list_reagents = list("foof" = 85, "cryogenic_fluid" = 15)
+
+/obj/item/weapon/reagent_containers/glass/bottle/nitroglycerin
+	name = "nitroglycerin bottle"
+	desc = "A small bottle. Contains nitroglycerin."
+	icon_state = "bottle16"
+	list_reagents = list("nitroglycerin" = 30)
+
+/obj/item/weapon/reagent_containers/glass/bottle/phlogiston
+	name = "phlogiston bottle"
+	desc = "A small bottle. Contains phlogiston."
+	icon_state = "bottle16"
+	list_reagents = list("phlogiston" = 30)
+
+/obj/item/weapon/reagent_containers/glass/bottle/napalm
+	name = "napalm bottle"
+	desc = "A small bottle. Contains napalm."
+	icon_state = "bottle16"
+	list_reagents = list("napalm" = 30)
+
+/obj/item/weapon/reagent_containers/glass/bottle/clf3
+	name = "chlorine trifluoride bottle"
+	desc = "A small bottle. Contains chlorine triflouride."
+	icon_state = "bottle16"
+	list_reagents = list("clf3" = 30)
+
+/obj/item/weapon/reagent_containers/glass/bottle/cryogenic_fluid
+	name = "cryogenic fluid bottle"
+	desc = "A small bottle. Contains cryogenic fluid."
+	icon_state = "bottle16"
+	list_reagents = list("cryogenic_fluid" = 30)
+
+/obj/item/weapon/reagent_containers/glass/bottle/thermite
+	name = "thermite bottle"
+	desc = "A small bottle. Contains thermite."
+	icon_state = "bottle16"
+	list_reagents = list("thermite" = 30)

--- a/html/changelogs/Banthebantz - Syndicate Pyrotechnics.yml
+++ b/html/changelogs/Banthebantz - Syndicate Pyrotechnics.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Banthebantz
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add neit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added Dioxygen Diflouride (commonly known as FOOF)"
+  - tweak: "FOOF is only obtainable as a chemist traitor. FOOF is highly dangerous, it adds tons of firestacks, ignites players, causes severe internal injuries, causes fireballs and can melt through the walls and floors effectively. As a downside, FOOF is also unstable and will decay into oxygen and fluorine unless in the presence of cryogenic fluid (which it slowly consumes)"
+  - rscadd: "Added new 8tc pyrotechnics kit for chemist traitors, this contains several dangerous pyrotechnic chemicals including FOOF"
+


### PR DESCRIPTION
Let's try this again.

Adds Dixoygen Difluoride (FOOF) as a chemist traitor exclusive. You should be able to get a more precise idea of what it does from the code but it essentially creates small very violent fires that melt the hull and walls of the station, on contact and if ingested it adds tons of firestacks and does a nasty amount of damage, it also decays over time unless in the presence of cryogenic fluid to stabilise.

Adds new 8tc syndicate pyrotechnic kit for tator chemists which contains FOOF and some other dangerous pyrotechnic stuff.

plz review code and stuff

vidya test: https://www.youtube.com/watch?v=_iizX00Uvmw
