### PR TITLE
Buffs Plasma Shots

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -201,8 +201,8 @@ obj/item/projectile/kinetic/New()
 	name = "plasma blast"
 	icon_state = "plasmacutter"
 	damage_type = BRUTE
-	damage = 5
-	range = 3
+	damage = 15
+	range = 6
 
 /obj/item/projectile/plasma/New()
 	var/turf/proj_turf = get_turf(src)
@@ -223,10 +223,13 @@ obj/item/projectile/kinetic/New()
 		M.gets_drilled(firer)
 		range = max(range - 1, 1)
 		return -1
+	if(isliving(target) && blocked = 0)
+		var/mob/M = target
+		M.add_reagent("plasma", pick(1,5))
 
 /obj/item/projectile/plasma/adv
-	range = 5
+	range = 7
 
 /obj/item/projectile/plasma/adv/mech
-	damage = 10
-	range = 6
+	damage = 30
+	range = 8

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -213,7 +213,7 @@ obj/item/projectile/kinetic/New()
 		var/pressure = environment.return_pressure()
 		if(pressure < 30)
 			name = "full strength plasma blast"
-			damage *= 3
+			damage *= 2
 	..()
 
 /obj/item/projectile/plasma/on_hit(atom/target)
@@ -223,13 +223,10 @@ obj/item/projectile/kinetic/New()
 		M.gets_drilled(firer)
 		range = max(range - 1, 1)
 		return -1
-	if(isliving(target) && blocked = 0)
-		var/mob/M = target
-		M.add_reagent("plasma", pick(1,5))
 
 /obj/item/projectile/plasma/adv
 	range = 7
 
 /obj/item/projectile/plasma/adv/mech
-	damage = 30
+	damage = 25
 	range = 8

--- a/html/changelogs/ArcLumin - Plasma.yml
+++ b/html/changelogs/ArcLumin - Plasma.yml
@@ -1,0 +1,4 @@
+author: ArcLumin
+delete-after: True
+changes: 
+  - tweak: "Buffs plasma cutters. Now they don't hit like wet paper."


### PR DESCRIPTION
Buffs plasma shots from plasma cutters so they don't hit like wet paper. Increases range and damage. Now you won't have to deal with 5 damage shots, which made no sense when shooting with what's supposed to be plasma.
