### PR TITLE
Updates simple mob summons + fixes egg conflict bug

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bigzeds.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bigzeds.dm
@@ -26,6 +26,7 @@
 	harm_intent_damage = 15
 	melee_damage_lower = 15
 	melee_damage_upper = 40
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/bigzed/Life()
 	if(istype(src, /mob/living/simple_animal/hostile/bigzed/scrake)) //For when I make the fleshpound. They'll both act differently when raged.

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -49,6 +49,9 @@
 			if(getorgan(/obj/item/organ/internal/body_egg/alien_embryo))
 				src << "<span class='userdanger'>A foreign presence repels us from this body. Perhaps we should try to infest another?</span>"
 				return
+			if(getorgan(/obj/item/organ/internal/body_egg/changeling_egg))
+				src << "<span class='userdanger'>One of us has already planted thier seed in this body! Perhaps we should try to infest another?</span>"
+				return
 			Infect(target)
 			src << "<span class='userdanger'>With our egg laid, our death approaches rapidly...</span>"
 			spawn(100)

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -21,7 +21,7 @@
 	var/datum/mind/origin
 	var/egg_lain = 0
 	speed = 0 //So you can actually fucking outrun the massive lynchsquad going after you
-	gold_core_spawnable = 0
+	gold_core_spawnable = 1
 	ventcrawl_speed = 5 //It's a tiny lil' piece of shit, he should be able to crawl into vents quick.
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
@@ -46,6 +46,9 @@
 		// Changeling egg can survive in aliens!
 		var/mob/living/carbon/C = target
 		if(C.stat == DEAD)
+			if(getorgan(/obj/item/organ/internal/body_egg/alien_embryo))
+				src << "<span class='userdanger'>A foreign presence repels us from this body. Perhaps we should try to infest another?</span>"
+				return
 			Infect(target)
 			src << "<span class='userdanger'>With our egg laid, our death approaches rapidly...</span>"
 			spawn(100)

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -21,7 +21,7 @@
 	var/datum/mind/origin
 	var/egg_lain = 0
 	speed = 0 //So you can actually fucking outrun the massive lynchsquad going after you
-	gold_core_spawnable = 1
+	gold_core_spawnable = 0
 	ventcrawl_speed = 5 //It's a tiny lil' piece of shit, he should be able to crawl into vents quick.
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -14,6 +14,7 @@
 	var/icon_aggro = null // for swapping to when we get aggressive
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_MINIMUM
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/asteroid/Aggro()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -146,6 +146,7 @@
 	var/alerted = 0
 	var/ore_eaten = 1
 	var/chase_time = 100
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/GiveTarget(new_target)
 	target = new_target
@@ -332,6 +333,7 @@
 	throw_message = "falls right through the strange body of the"
 	environment_smash = 0
 	pass_flags = PASSTABLE
+	gold_core_spawnable = 0
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/New()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -26,6 +26,7 @@
 	mob_size = MOB_SIZE_TINY
 	flying = 1
 	speak_emote = list("squeaks")
+	gold_core_spawnable = 1
 	var/max_co2 = 0 //to be removed once metastation map no longer use those for Sgt Araneus
 	var/min_oxy = 0
 	var/max_tox = 0

--- a/code/modules/mob/living/simple_animal/hostile/shark.dm
+++ b/code/modules/mob/living/simple_animal/hostile/shark.dm
@@ -22,7 +22,7 @@
 	melee_damage_upper = 18
 	attacktext = "maims"
 	attack_sound = 'sound/weapons/bite.ogg'
-
+	gold_core_spawnable = 1
 	//Space shark aren't affected by cold.
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -29,8 +29,6 @@
 		if (chemical_mob_spawn_meancritters.len <= 0 || chemical_mob_spawn_nicecritters.len <= 0)
 			for (var/T in typesof(/mob/living/simple_animal))
 				var/mob/living/simple_animal/SA = T
-				if(istype(T,/mob/living/simple_animal/hostile/headcrab))
-					continue //Prevents headslugs from the golden slimes
 				switch(initial(SA.gold_core_spawnable))
 					if(1)
 						chemical_mob_spawn_meancritters += T

--- a/html/changelogs/arclumin - spawn.yml
+++ b/html/changelogs/arclumin - spawn.yml
@@ -1,0 +1,5 @@
+author: ArcLumin
+delete-after: True
+changes: 
+  - tweak: "Adds sharks, hivelords, goliaths, headcrabs, basilisks, fugus, and bats to hostile mob summons"
+  - bugfix: "Fixes conflicts where two eggs in one body would cause issues when hatching"


### PR DESCRIPTION
Adds sharks, hivelords, goliaths, scrakes, basilisks, fugus, and bats to hostile mob summons. Removes a unnecessary line in the spawning file.

Adds goldgrubs to passive mob summons.

Also fixes headslugs being able to plant eggs in xeno hosted bodies, causing issues.

Fixes headslug eggs conflicting when two eggs are implanted, causing the 2nd planted egg to gain the body.
