### PR TITLE
Nerfs the Owl Hardsuit

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -323,6 +323,8 @@
 	icon_state = "hardsuit1-owl"
 	item_state = "s_suit"
 	item_color = "owl"
+	body_parts_covered = ARMS
+	flags_inv = HIDEGLOVES
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/owl
 	armor = list(melee = 30, bullet = 15, laser = 30, energy = 10, bomb = 10, bio = 100, rad = 50)
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -313,6 +313,7 @@
 	icon_state = "hardsuit1-owl"
 	item_state = "s_helmet"
 	item_color = "owl"
+	armor = list(melee = 15, bullet = 15, laser = 15, energy = 10, bomb = 10, bio = 100, rad = 50) //Why in gods name was a thing that non antags could get inside of 30 seconds of roundstart AS GOOD as something normal traitors had to spend TC on?
 
 
 /obj/item/clothing/suit/space/hardsuit/syndi/owl
@@ -323,6 +324,7 @@
 	item_state = "s_suit"
 	item_color = "owl"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/owl
+	armor = list(melee = 15, bullet = 15, laser = 15, energy = 10, bomb = 10, bio = 100, rad = 50)
 
 /obj/item/clothing/suit/space/hardsuit/syndi/owl/cursed
 	flags = NODROP | THICKMATERIAL

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -323,13 +323,12 @@
 	icon_state = "hardsuit1-owl"
 	item_state = "s_suit"
 	item_color = "owl"
-	body_parts_covered = ARMS
 	flags_inv = HIDEGLOVES
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/owl
 	armor = list(melee = 30, bullet = 15, laser = 30, energy = 10, bomb = 10, bio = 100, rad = 50)
 
 /obj/item/clothing/suit/space/hardsuit/syndi/owl/cursed
-	flags = NODROP | THICKMATERIAL
+	flags = NODROP
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/owl/attack_self(mob/user) //Toggle Helmet
 	if(!isturf(user.loc))

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -313,7 +313,7 @@
 	icon_state = "hardsuit1-owl"
 	item_state = "s_helmet"
 	item_color = "owl"
-	armor = list(melee = 15, bullet = 15, laser = 15, energy = 10, bomb = 10, bio = 100, rad = 50) //Why in gods name was a thing that non antags could get inside of 30 seconds of roundstart AS GOOD as something normal traitors had to spend TC on?
+	armor = list(melee = 30, bullet = 15, laser = 30, energy = 10, bomb = 10, bio = 100, rad = 50) //Why in gods name was a thing that non antags could get inside of 30 seconds of roundstart AS GOOD as something normal traitors had to spend TC on?
 
 
 /obj/item/clothing/suit/space/hardsuit/syndi/owl
@@ -324,10 +324,58 @@
 	item_state = "s_suit"
 	item_color = "owl"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/owl
-	armor = list(melee = 15, bullet = 15, laser = 15, energy = 10, bomb = 10, bio = 100, rad = 50)
+	armor = list(melee = 30, bullet = 15, laser = 30, energy = 10, bomb = 10, bio = 100, rad = 50)
 
 /obj/item/clothing/suit/space/hardsuit/syndi/owl/cursed
 	flags = NODROP | THICKMATERIAL
+
+/obj/item/clothing/head/helmet/space/hardsuit/syndi/owl/attack_self(mob/user) //Toggle Helmet
+	if(!isturf(user.loc))
+		user << "<span class='warning'>You cannot toggle your helmet while in this [user.loc]!</span>" //To prevent some lighting anomalities.
+		return
+	on = !on
+	if(on || force)
+		user << "<span class='notice'>You switch your hardsuit to travel mode.</span>"
+		name = initial(name)
+		desc = initial(desc)
+		user.AddLuminosity(brightness_on)
+		flags |= STOPSPRESSUREDMAGE | THICKMATERIAL
+		flags_cover |= HEADCOVERSEYES | HEADCOVERSMOUTH
+		flags_inv |= HIDEMASK|HIDEEYES|HIDEFACE
+		cold_protection |= HEAD
+	else
+		user << "<span class='notice'>You switch your hardsuit to combat mode.</span>"
+		name += " (combat)"
+		desc = alt_desc
+		user.AddLuminosity(-brightness_on)
+		flags &= ~(STOPSPRESSUREDMAGE | THICKMATERIAL)
+		flags_cover &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
+		flags_inv &= ~(HIDEMASK|HIDEEYES|HIDEFACE)
+		cold_protection &= ~HEAD
+	update_icon()
+	playsound(src.loc, 'sound/mecha/mechmove03.ogg', 50, 1)
+	toggle_owlhardsuit_mode(user)
+	user.update_inv_head()
+
+/obj/item/clothing/head/helmet/space/hardsuit/syndi/proc/toggle_owlhardsuit_mode(mob/user) //Helmet Toggles Suit Mode
+	if(linkedsuit)
+		if(on)
+			linkedsuit.name = initial(linkedsuit.name)
+			linkedsuit.desc = initial(linkedsuit.desc)
+			linkedsuit.slowdown = 1
+			linkedsuit.flags |= STOPSPRESSUREDMAGE | THICKMATERIAL
+			linkedsuit.cold_protection |= CHEST | GROIN | LEGS | FEET | ARMS | HANDS
+		else
+			linkedsuit.name += " (combat)"
+			linkedsuit.desc = linkedsuit.alt_desc
+			linkedsuit.slowdown = 0
+			linkedsuit.flags &= ~(STOPSPRESSUREDMAGE | THICKMATERIAL)
+			linkedsuit.cold_protection &= ~(CHEST | GROIN | LEGS | FEET | ARMS | HANDS)
+
+		linkedsuit.icon_state = "hardsuit[on]-[item_color]"
+		linkedsuit.update_icon()
+		user.update_inv_wear_suit()
+		user.update_inv_w_uniform()
 
 	//Wizard hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/wizard

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -8,9 +8,9 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	w_class = 4
 	slot_flags = SLOT_BACK
-	armor =              list(melee = 30, bullet = 30, laser = 15, energy = 15, bomb = 30, bio = 20, rad = 20)
-	var/armor_backslot = list(melee = 30, bullet = 30, laser = 15, energy = 15, bomb = 30, bio = 20, rad = 20)
-	var/armor_exoslot =  list(melee = 60, bullet = 60, laser = 30, energy = 30, bomb = 60, bio = 40, rad = 30)
+	armor =              list(melee = 15, bullet = 15, laser = 15, energy = 10, bomb = 30, bio = 20, rad = 20)
+	var/armor_backslot = list(melee = 15, bullet = 15, laser = 15, energy = 10, bomb = 30, bio = 20, rad = 20)//To minimise stacking the damn thing with the hardsuit to be pretty stun resistant.
+	var/armor_exoslot =  list(melee = 30, bullet = 30, laser = 30, energy = 10, bomb = 60, bio = 40, rad = 30)// This was debatably better armour than the hardsuit alone, its just stacking it with the armour made it "worse".
 	var/adjusted = 0
 	max_w_class = 3
 	max_combined_w_class = 15

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -9,8 +9,8 @@
 	w_class = 4
 	slot_flags = SLOT_BACK
 	armor =              list(melee = 15, bullet = 15, laser = 15, energy = 10, bomb = 30, bio = 20, rad = 20)
-	var/armor_backslot = list(melee = 15, bullet = 15, laser = 15, energy = 10, bomb = 30, bio = 20, rad = 20)//To minimise stacking the damn thing with the hardsuit to be pretty stun resistant.
-	var/armor_exoslot =  list(melee = 30, bullet = 30, laser = 30, energy = 10, bomb = 60, bio = 40, rad = 30)// This was debatably better armour than the hardsuit alone, its just stacking it with the armour made it "worse".
+	var/armor_backslot = list(melee = 15, bullet = 15, laser = 15, energy = 10, bomb = 30, bio = 20, rad = 20)//To minimise stacking the damn thing with the hardsuit to be pretty resistant to stuns.
+	var/armor_exoslot =  list(melee = 30, bullet = 30, laser = 30, energy = 10, bomb = 60, bio = 40, rad = 30)//This was debatably better armour than the hardsuit alone, it's just stacking it with the armour made it "worse".
 	var/adjusted = 0
 	max_w_class = 3
 	max_combined_w_class = 15

--- a/html/changelogs/Guyonbroadway - Nerfs owl crap.yml
+++ b/html/changelogs/Guyonbroadway - Nerfs owl crap.yml
@@ -33,5 +33,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Reduced the protection values of the owl hardsuit and brown owl cloak found in space, especially the energy resistance values."
+  - tweak: "Reduced the protection values of the owl hardsuit and brown owl cloak found in space, especially the energy resistance values and is now on par with the sec hardsuit. It is also now vulnerable to syringes while in combat mode."
  

--- a/html/changelogs/Guyonbroadway - Nerfs owl crap.yml
+++ b/html/changelogs/Guyonbroadway - Nerfs owl crap.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: GuyonBroadway
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Reduced the protection values of the owl hardsuit and brown owl cloak found in space, especially the energy resistance values."
+ 

--- a/html/changelogs/Guyonbroadway - Nerfs owl crap.yml
+++ b/html/changelogs/Guyonbroadway - Nerfs owl crap.yml
@@ -33,5 +33,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Reduced the protection values of the owl hardsuit and brown owl cloak found in space, especially the energy resistance values and is now on par with the sec hardsuit. It is also now vulnerable to syringes while in combat mode."
+  - tweak: "Reduced the protection values of the owl hardsuit and brown owl cloak found in space, especially the energy resistance values and is now on par with the sec hardsuit. It is also now vulnerable to syringes while in combat mode and you can take stuff out of their pockets and remove their belt, no more cheesing KOTD with the owl suit you fucks."
  


### PR DESCRIPTION
The owl hardsuit found in space had the same protective values as a syndicate hardsuit, which is either a somewhat expensive traitor item or the mainstay of nuclear operatives. Something like that should not be easily fucking accessible within 30 seconds of roundstart. 

Not to mention how with some augmentations, a sec jumpsuit and the cloak you could render yourself literally immune to any melee weapon short of an e-sword, you have no slowdown in combat mode AND energy resistance enough that there isn't enough time to cuff someone after stunning them with a taser. 

Acceptable benefits for antag gear yes but as an item literally ANY ding dong with a screwdriver and a multitool can get? No fukken way. 