### PR TITLE
Fixes MMI Ghosting

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -117,6 +117,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 				return
 			else
 				confirm_ghost = TRUE
+		else
+			confirm_ghost = TRUE
 	else
 		confirm_ghost = TRUE
 

--- a/html/changelogs/Creeper Joe - Fix MMI Ghosting.yml
+++ b/html/changelogs/Creeper Joe - Fix MMI Ghosting.yml
@@ -1,0 +1,6 @@
+author: Creeper Joe
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed MMI Ghosting after 9 years in development"


### PR DESCRIPTION
And probably a few other things because it was a shitty oversight that's been in the code for way too long.

For those that are wondering: Yes, it were Cluwnes. No, I did not need to remove them.

Fixes #3094 and #2803 