### PR TITLE
Bloodcrawl can no longer be cast on the Centcomm Z-Level

### DIFF
--- a/code/datums/spells/bloodcrawl.dm
+++ b/code/datums/spells/bloodcrawl.dm
@@ -6,6 +6,7 @@
 	selection_type = "range"
 	range = 1
 	cooldown_min = 0
+	centcom_cancast = 0
 	overlay = null
 	action_icon_state = "bloodcrawl"
 	action_background_icon_state = "bg_demon"

--- a/html/changelogs/Creeper Joe - Bloodcrawl fix.yml
+++ b/html/changelogs/Creeper Joe - Bloodcrawl fix.yml
@@ -1,0 +1,7 @@
+author: Creeper Joe
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed an exploit that allowed you to reach Centcomm by using Bloodcrawl"
+  - tweak: "Bloodcrawl can't be cast on the Centcomm Z-Level anymore."


### PR DESCRIPTION
Fixes #2979

Considered an exploit fix as Slaughter Demon's aren't supposed to be on Centcomm anyways, nor anyone else that has eaten their heart.