### PR TITLE
Fixes Book of Darkness spells not carrying over with Lichdom

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -932,13 +932,13 @@
 	user << "<font color=purple><b>Soulsplit</b></font> let's you become incorporeal for 3.5 seconds, allowing you to phase through objects and walk at very high speeds. However, it cannot be cast if you are below 100 health. In addition, you are still vulnerable to damage and other attacks in this state, nor will it remove any stuns."
 	user << "<font color=purple><b>Your robes</b></font> have increased resistance against all damage and will help convey your peaceful intent towards the still living."
 	soulflare = new /obj/effect/proc_holder/spell/targeted/trigger/soulflare
-	user.AddSpell(soulflare)
+	user.mind.AddSpell(soulflare)
 
 	explodecorpse = new /obj/effect/proc_holder/spell/targeted/explodecorpse
-	user.AddSpell(explodecorpse)
+	user.mind.AddSpell(explodecorpse)
 
 	soulsplit = new /obj/effect/proc_holder/spell/self/soulsplit
-	user.AddSpell(soulsplit)
+	user.mind.AddSpell(soulsplit)
 
 	new /obj/item/weapon/gun/magic/staff/staffofrevenant(get_turf(user))
 	new /obj/item/clothing/suit/wizrobe/necrolord(get_turf(user))

--- a/html/changelogs/Creeper Joe - Book of Dankness lichdom fix.yml
+++ b/html/changelogs/Creeper Joe - Book of Dankness lichdom fix.yml
@@ -1,0 +1,6 @@
+author: Creeper Joe
+
+delete-after: True
+
+changes:
+  - bugfix: "Book of Darkness spells now properly carry over with Lichdom"


### PR DESCRIPTION
Fixes #3147 

The spells were tied to the mob not to the mind, which is ironic how it's a necromancy set and it's all about binding the mind to the bones and all that shit.