### PR TITLE
Book of Darkness tweaks.

### DIFF
--- a/code/datums/spells/lordspells.dm
+++ b/code/datums/spells/lordspells.dm
@@ -25,7 +25,7 @@
 	sound="sound/magic/Necrolord_Soulflare_Cast.ogg"
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/soulflare/cast(list/targets, mob/user = usr)
-	var/obj/effect/proc_holder/spell/targeted/trigger/soulflare/SF = locate(/obj/effect/proc_holder/spell/targeted/trigger/soulflare, user.mob_spell_list)
+	var/obj/effect/proc_holder/spell/targeted/trigger/soulflare/SF = locate(/obj/effect/proc_holder/spell/targeted/trigger/soulflare, user.mind.spell_list)
 	var/mob/living/carbon/target = targets[1]
 	if(target.health <= 0)
 		if(!target.stat && DEAD)

--- a/code/datums/spells/lordspells.dm
+++ b/code/datums/spells/lordspells.dm
@@ -57,12 +57,12 @@
 
 /obj/effect/proc_holder/spell/targeted/explodecorpse/cast(list/targets, mob/user = usr)
 	..()
-	var/mob/living/carbon/target = targets[1]
+	var/mob/living/carbon/human/target = targets[1]
 	if(!target)
 		return
 	if(target.stat & DEAD)
 		message_admins("[user] casted corpse explosion on [target]")
-		explosion(target,1,2,5)
+		explosion(target,1,2,4,2)
 		user << "<font color=purple><b>You redirect an absurd amount of energy into [target]'s corpse, causing it to violently explode!</b></font>"
 	else
 		user << "<span class='warning'>[target] isn't a dead corpse!</span>"

--- a/code/datums/spells/lordspells.dm
+++ b/code/datums/spells/lordspells.dm
@@ -70,7 +70,7 @@
 
 /obj/effect/proc_holder/spell/self/soulsplit
 	name = "Soulsplit"
-	desc = "Enter a wraith-like form, traveling at very high speeds and moving through objects. However, maintaining this form requires you to be at full health to maintain concentration!"
+	desc = "Enter a wraith-like form, traveling at very high speeds and moving through objects. However, maintaining this form requires you to be at 90 health to maintain concentration!"
 	school = "transmutation"
 	charge_max = 300
 	clothes_req = 1
@@ -82,7 +82,7 @@
 	action_icon_state = "soulsplit"
 
 /obj/effect/proc_holder/spell/self/soulsplit/cast(list/targets, mob/living/user = usr)
-	if(user.health >= 100)
+	if(user.health >= 90)
 		user << "<font color=purple><b>You enter your wraith form, leaving you vulnerable yet very manoeuvrable.</b></font>"
 		user.incorporeal_move = 2
 		spawn(35)

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -76,7 +76,7 @@
 
 /obj/item/weapon/gun/magic/staff/staffofrevenant/attack(mob/living/carbon/human/target, mob/living/user)
 	if(target.stat & DEAD)
-		if(istype(target, mob/living/carbon/human)
+		if(istype(target, mob/living/carbon/human))
 			if(!(target in drained_mobs))
 				playsound(src,'sound/magic/Staff_Chaos.ogg',40,1)
 				user.visible_message("<font color=purple>[user] drains [target] their soul with [src]!</font>", "<span class='notice'>You use [src] to drain [target]'s soul, empowering your weapon!</span>")

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -76,7 +76,7 @@
 
 /obj/item/weapon/gun/magic/staff/staffofrevenant/attack(mob/living/carbon/human/target, mob/living/user)
 	if(target.stat & DEAD)
-		if(istype(target, mob/living/carbon/human))
+		if(istype(target, /mob/living/carbon/human))
 			if(!(target in drained_mobs))
 				playsound(src,'sound/magic/Staff_Chaos.ogg',40,1)
 				user.visible_message("<font color=purple>[user] drains [target] their soul with [src]!</font>", "<span class='notice'>You use [src] to drain [target]'s soul, empowering your weapon!</span>")

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -76,13 +76,17 @@
 
 /obj/item/weapon/gun/magic/staff/staffofrevenant/attack(mob/living/carbon/human/target, mob/living/user)
 	if(target.stat & DEAD)
-		if(!(target in drained_mobs))
-			playsound(src,'sound/magic/Staff_Chaos.ogg',40,1)
-			user.visible_message("<font color=purple>[user] drains [target] their soul with [src]!</font>", "<span class='notice'>You use [src] to drain [target]'s soul, empowering your weapon!</span>")
-			revenant_souls++
-			drained_mobs.Add(target)
+		if(istype(target, mob/living/carbon/human)
+			if(!(target in drained_mobs))
+				playsound(src,'sound/magic/Staff_Chaos.ogg',40,1)
+				user.visible_message("<font color=purple>[user] drains [target] their soul with [src]!</font>", "<span class='notice'>You use [src] to drain [target]'s soul, empowering your weapon!</span>")
+				revenant_souls++
+				drained_mobs.Add(target)
+			else
+				user << "<span class='warning'>[target]'s soul is dead and empty.</span>"
+				return
 		else
-			user << "<span class='warning'>[target]'s soul is dead and empty.</span>"
+			user << "<span class='warning'>[target] isn't human!</span>"
 			return
 	..()
 

--- a/html/changelogs/Creeper Joe - Necrolord tweaks.yml
+++ b/html/changelogs/Creeper Joe - Necrolord tweaks.yml
@@ -3,6 +3,7 @@ author: Creeper Joe
 delete-after: True
 
 changes:
-  - tweak: "The Staff of Revenants now only works on humans."
+  - tweak: "The Staff of Revenant now only works on humans."
   - tweak: "Corpse Explosion now only works on humans and it's maximum range has been reduced by 1."
   - tweak: "Soulsplit only requires 90 or less health instead of 100."
+  - bugfix: "Fixed a bug where soulflare tried looking for the spell in your mob instead of your mind."

--- a/html/changelogs/Creeper Joe - Necrolord tweaks.yml
+++ b/html/changelogs/Creeper Joe - Necrolord tweaks.yml
@@ -1,0 +1,8 @@
+author: Creeper Joe
+
+delete-after: True
+
+changes:
+  - tweak: "The Staff of Revenants now only works on humans."
+  - tweak: "Corpse Explosion now only works on humans and it's maximum range has been reduced by 1."
+  - tweak: "Soulsplit only requires 90 or less health instead of 100."


### PR DESCRIPTION
Staff of Revenant and Corpse Explosion now only work on humans.
Corpse Explosion's range has been reduced by 1 (basically making it a syndicate minibomb)
Soulsplit now only requires 90 or more health to cast.

Also fixes Soulflare being broken again.

Fixes #3172 