### PR TITLE
Alters Sniper Scope

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -493,10 +493,10 @@
 
 	if(zoomed)
 		user.client.view = (world.view + zoom_amt)
-		user.slowdown = (initial(slowdown) + 3)
+		src.slowdown = (initial(slowdown) + 3)
 	else
 		user.client.view = world.view
-		user.slowdown = initial(slowdown)
+		src.slowdown = initial(slowdown)
 
 //Proc, so that gun accessories/scopes/etc. can easily add zooming.
 /obj/item/weapon/gun/proc/build_zooming()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -492,7 +492,7 @@
 
 	if(zoomed)
 		user.client.view = (world.view + zoom_amt)
-		if(user.moving)
+		if(user.move)
 			user.client.view = world.view
 			zoomed = FALSE
 	else

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -494,6 +494,7 @@
 		user.client.view = (world.view + zoom_amt)
 		if(user.moving)
 			user.client.view = world.view
+			zoomed = FALSE
 	else
 		user.client.view = world.view
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -492,11 +492,10 @@
 
 	if(zoomed)
 		user.client.view = (world.view + zoom_amt)
-		if(user.Move)
-			user.client.view = world.view
-			zoomed = FALSE
+		user.canmove = 0
 	else
 		user.client.view = world.view
+		user.canmove = 1
 
 //Proc, so that gun accessories/scopes/etc. can easily add zooming.
 /obj/item/weapon/gun/proc/build_zooming()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -463,6 +463,7 @@
 	check_flags = AB_CHECK_ALIVE|AB_CHECK_RESTRAINED|AB_CHECK_STUNNED|AB_CHECK_LYING
 	button_icon_state = "sniper_zoom"
 	var/obj/item/weapon/gun/gun = null
+	var/
 
 /datum/action/toggle_scope_zoom/Trigger()
 	gun.zoom(owner)
@@ -492,10 +493,10 @@
 
 	if(zoomed)
 		user.client.view = (world.view + zoom_amt)
-		gun.slowdown += 3
+		user.slowdown = (initial(slowdown) + 3)
 	else
 		user.client.view = world.view
-		gun.slowdown -= 3
+		user.slowdown = initial(slowdown)
 
 //Proc, so that gun accessories/scopes/etc. can easily add zooming.
 /obj/item/weapon/gun/proc/build_zooming()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -491,14 +491,11 @@
 			zoomed = !zoomed
 
 	if(zoomed)
-		var/usedloc = null
-		user.loc = usedloc
 		user.client.view = (world.view + zoom_amt)
-		if(usedloc != user.loc)
-			user.client.view = world.view
-			..()
+		gun.slowdown += 3
 	else
 		user.client.view = world.view
+		gun.slowdown -= 3
 
 //Proc, so that gun accessories/scopes/etc. can easily add zooming.
 /obj/item/weapon/gun/proc/build_zooming()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -492,7 +492,7 @@
 
 	if(zoomed)
 		user.client.view = (world.view + zoom_amt)
-		src.slowdown = (initial(slowdown) + 3)
+		src.slowdown = (initial(slowdown) + 4)
 	else
 		user.client.view = world.view
 		src.slowdown = initial(slowdown)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -66,7 +66,7 @@
 	//Zooming
 	var/zoomable = FALSE //whether the gun generates a Zoom action on creation
 	var/zoomed = FALSE //Zoom toggle
-	var/zoom_amt = 3 //Distance in TURFs to move the user's screen forward (the "zoom" effect)
+	var/zoom_amt = 7 //Distance in TURFs to move the user's screen forward (the "zoom" effect)
 	var/datum/action/toggle_scope_zoom/azoom
 
 
@@ -491,24 +491,9 @@
 			zoomed = !zoomed
 
 	if(zoomed)
-		var/_x = 0
-		var/_y = 0
-		switch(user.dir)
-			if(NORTH)
-				_y = zoom_amt
-			if(EAST)
-				_x = zoom_amt
-			if(SOUTH)
-				_y = -zoom_amt
-			if(WEST)
-				_x = -zoom_amt
-
-		user.client.pixel_x = world.icon_size*_x
-		user.client.pixel_y = world.icon_size*_y
+		user.client.view = (world.view + zoom_amt)
 	else
-		user.client.pixel_x = 0
-		user.client.pixel_y = 0
-
+		user.client.view = world.view
 
 //Proc, so that gun accessories/scopes/etc. can easily add zooming.
 /obj/item/weapon/gun/proc/build_zooming()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -496,6 +496,7 @@
 		user.client.view = (world.view + zoom_amt)
 		if(usedloc != user.loc)
 			user.client.view = world.view
+			..()
 	else
 		user.client.view = world.view
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -492,8 +492,10 @@
 
 	if(zoomed)
 		user.client.view = (world.view + zoom_amt)
+		user.anchored = 1
 	else
 		user.client.view = world.view
+		user.anchored = 0
 
 //Proc, so that gun accessories/scopes/etc. can easily add zooming.
 /obj/item/weapon/gun/proc/build_zooming()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -492,10 +492,10 @@
 
 	if(zoomed)
 		var/usedloc = null
-		user.loc == usedloc
+		user.loc = usedloc
 		user.client.view = (world.view + zoom_amt)
-			if(usedloc != user.loc)
-				user.client.view = world.view
+		if(user.loc != usedloc)
+			user.client.view = world.view
 	else
 		user.client.view = world.view
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -492,7 +492,7 @@
 
 	if(zoomed)
 		user.client.view = (world.view + zoom_amt)
-		if(user.move)
+		if(user.Move)
 			user.client.view = world.view
 			zoomed = FALSE
 	else

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -492,10 +492,10 @@
 
 	if(zoomed)
 		user.client.view = (world.view + zoom_amt)
-		user.anchored = 1
+		if(user.moving)
+			user.client.view = world.view
 	else
 		user.client.view = world.view
-		user.anchored = 0
 
 //Proc, so that gun accessories/scopes/etc. can easily add zooming.
 /obj/item/weapon/gun/proc/build_zooming()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -463,7 +463,6 @@
 	check_flags = AB_CHECK_ALIVE|AB_CHECK_RESTRAINED|AB_CHECK_STUNNED|AB_CHECK_LYING
 	button_icon_state = "sniper_zoom"
 	var/obj/item/weapon/gun/gun = null
-	var/
 
 /datum/action/toggle_scope_zoom/Trigger()
 	gun.zoom(owner)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -491,11 +491,13 @@
 			zoomed = !zoomed
 
 	if(zoomed)
+		var/usedloc = null
+		user.loc == usedloc
 		user.client.view = (world.view + zoom_amt)
-		user.canmove = 0
+			if(usedloc != user.loc)
+				user.client.view = world.view
 	else
 		user.client.view = world.view
-		user.canmove = 1
 
 //Proc, so that gun accessories/scopes/etc. can easily add zooming.
 /obj/item/weapon/gun/proc/build_zooming()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -494,7 +494,7 @@
 		var/usedloc = null
 		user.loc = usedloc
 		user.client.view = (world.view + zoom_amt)
-		if(user.loc != usedloc)
+		if(usedloc != user.loc)
 			user.client.view = world.view
 	else
 		user.client.view = world.view

--- a/html/changelogs/ArcLumin - zoom snipe.yml
+++ b/html/changelogs/ArcLumin - zoom snipe.yml
@@ -1,4 +1,4 @@
 author: ArcLumin
 delete-after: True
 changes: 
-  - tweak: "Alters sniper rifle to now zoom out 14 tiles in all directions, but if you move while you're zoomed out it cancels the zoom"
+  - tweak: "Alters sniper rifle to now zoom out 14 tiles in all directions, but you can't move while zoomed out"

--- a/html/changelogs/ArcLumin - zoom snipe.yml
+++ b/html/changelogs/ArcLumin - zoom snipe.yml
@@ -1,0 +1,4 @@
+author: ArcLumin
+delete-after: True
+changes: 
+  - tweak: "Alters sniper rifle to now zoom out 14 tiles in all directions, but you're now anchored to the ground while you're zoomed out"

--- a/html/changelogs/ArcLumin - zoom snipe.yml
+++ b/html/changelogs/ArcLumin - zoom snipe.yml
@@ -1,4 +1,4 @@
 author: ArcLumin
 delete-after: True
 changes: 
-  - tweak: "Alters sniper rifle to now zoom out 14 tiles in all directions, but you're now anchored to the ground while you're zoomed out"
+  - tweak: "Alters sniper rifle to now zoom out 14 tiles in all directions, but if you move while you're zoomed out it cancels the zoom"

--- a/html/changelogs/ArcLumin - zoom snipe.yml
+++ b/html/changelogs/ArcLumin - zoom snipe.yml
@@ -1,4 +1,4 @@
 author: ArcLumin
 delete-after: True
 changes: 
-  - tweak: "Alters sniper rifle to now zoom out 14 tiles in all directions, but you can't move while zoomed out"
+  - bugfix: "Alters sniper rifle to now zoom out 14 tiles in all directions, but you move slowly while zoomed out. Should fix sniper rifle aiming bugs"


### PR DESCRIPTION
Alters sniper scope from the buggy offset shit it was previously, now it increases client view range rather than offsetting it. It also now anchors you down while it's zoomed in. Now maybe the sniper rifle will be useful?

This framework also will work for adding scopes to normal guns.

Zooming in makes you move slower.