### PR TITLE
Fixes #2367 and tweaks galaxy superfart

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -25,7 +25,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	new /obj/effect/immovablerod(startT, endT)
 
 /obj/effect/immovablerod
-	name = "Immovable Rod"
+	name = "immovable rod"
 	desc = "What the fuck is that?"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "immrod"
@@ -34,15 +34,20 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	anchored = 1
 	var/z_original = 0
 	var/destination
+
 /obj/effect/immovablerod/butt
 	name = "gigantic ass"
 	desc = "godDAMN that ass is well rounded"
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "butt"
+
 /obj/effect/immovablerod/New(atom/start, atom/end)
 	loc = start
 	z_original = z
 	destination = end
+	for(var/atom/a in range(0))
+		if(a != src)
+			src.Bump(a)
 	if(end && end.z==z_original)
 		walk_towards(src, destination, 1)
 
@@ -70,7 +75,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	else if (istype(clong, /mob))
 		if(istype(clong, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = clong
-			H.visible_message("<span class='danger'>[H.name] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
+			H.visible_message("<span class='danger'>[H.name] is penetrated by an immovable [name]!</span>" , "<span class='userdanger'>The [name] penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
 			H.adjustBruteLoss(160)
 		if(clong.density || prob(10))
 			clong.ex_act(2)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -75,7 +75,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	else if (istype(clong, /mob))
 		if(istype(clong, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = clong
-			H.visible_message("<span class='danger'>[H.name] is penetrated by an immovable [name]!</span>" , "<span class='userdanger'>The [name] penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
+			H.visible_message("<span class='danger'>[H.name] is penetrated by an [name]!</span>" , "<span class='userdanger'>The [name] penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
 			H.adjustBruteLoss(160)
 		if(clong.density || prob(10))
 			clong.ex_act(2)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -454,6 +454,8 @@
 				fart_type = 2
 			else if(prob(12)) // 0.4%
 				fart_type = 3
+				if(loc.z != 1)
+					fart_type = 2
 			spawn(0)
 				spawn(1)
 					for(var/obj/item/weapon/storage/book/bible/Y in range(0))
@@ -515,38 +517,28 @@
 						gib()
 
 					if(3)
-						var/startx = 0
-						var/starty = 0
 						var/endy = 0
 						var/endx = 0
-						var/startside = pick(cardinal)
 
-						switch(startside)
+						switch(dir)
 							if(NORTH)
-								starty = loc
-								startx = loc
-								endy = 38
-								endx = rand(41, 199)
+								endy = 8
+								endx = loc.x
 							if(EAST)
-								starty = loc
-								startx = loc
-								endy = rand(38, 187)
-								endx = 41
+								endy = loc.y
+								endx = 8
 							if(SOUTH)
-								starty = loc
-								startx = loc
-								endy = 187
-								endx = rand(41, 199)
+								endy = 247
+								endx = loc.x
 							else
-								starty = loc
-								startx = loc
-								endy = rand(38, 187)
-								endx = 199
+								endy = loc.y
+								endx = 247
 
 						//ASS BLAST USA
 						visible_message("\red <b>[src]</b> blows their ass off with such force, they explode!", "\red Holy shit, your butt flies off into the galaxy!")
 						gib() //can you belive I forgot to put this here?? yeah you need to see the message BEFORE you gib
-						new /obj/effect/immovablerod/butt(locate(startx, starty, 1), locate(endx, endy, 1))
+						qdel(B)
+						new /obj/effect/immovablerod/butt(loc, locate(endx, endy, 1))
 						priority_announce("What the fuck was that?!", "General Alert")
 
 		if ("whimper","whimpers")

--- a/html/changelogs/Kitty Kathy - AssBlastUSA.yml
+++ b/html/changelogs/Kitty Kathy - AssBlastUSA.yml
@@ -1,0 +1,17 @@
+# Your name.  
+author: Kitty Kathy
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Galaxy superfart now works, but works a bit different that the original code."
+  - tweak: "Galaxy superfart does not shoot off into a random direction it goes opposite what you are facing."
+  - tweak: "Galaxy superfart will also move in a straight line until it reaches the end of the map."
+  - tweak: "Immovable rods and their children now bump into whatever they spawn on."
+  - tweak: "You can not galaxy superfart on any zlevel other than 1, it will instead go supernova if it picks that."


### PR DESCRIPTION
   :cl: Kitty Kathy
   bugfix: Galaxy superfart now works, but works a bit different that the original code.
   tweak: Galaxy superfart does not shoot off into a random direction it goes opposite what you are facing.
   tweak: Galaxy superfart will also move in a straight line until it reaches the end of the map.
   tweak: Immovable rods and their children now bump into whatever they spawn on.
   tweak: You can not galaxy superfart on any zlevel other than 1, it will instead go supernova if it picks that.
   /:cl:
Fixes #2367.
Am i doing this automatic changelog thing right?
I have no idea what I am doing to be honest never used git before.
Yes I tested this and it works unless something went horribly wrong when i was fooling around with the command line trying to get this to work.
*Edited wrong issue number