### PR TITLE
Buffs Penned Nerf Darts

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -313,7 +313,7 @@
 		if(!user.unEquip(A))
 			return
 		A.loc = BB
-		BB.damage = 5
+		BB.damage += 10
 		user << "<span class='notice'>You insert [A] into [src].</span>"
 	return
 


### PR DESCRIPTION
Adding a pen to a nerf dart now boosts the damage of the dart from 5 to 11